### PR TITLE
Sparse covariance matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ os:
   - osx
 julia:
   - release
-  - nightly 
+  - nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("PDMats"); Pkg.test("PDMats"; coverage=true)'
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("PDMats"); Pkg.test("PDMats"; coverage=true)'
+after_success:
+  - julia -e 'cd(Pkg.dir("PDMats")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # PDMats.jl
 
-Uniform interface for positive definite matrices of various structures. 
+Uniform interface for positive definite matrices of various structures.
 [![Build Status](https://travis-ci.org/JuliaStats/PDMats.jl.png?branch=master)](https://travis-ci.org/JuliaStats/PDMats.jl)
 
 --------------
 
-Positive definite matrices are widely used in machine learning and probabilistic modeling, especially in applications related to graph analysis and Gaussian models. It is not uncommon that positive definite matrices used in practice have special structures (e.g. diagonal), which can be exploited to accelerate computation. 
+Positive definite matrices are widely used in machine learning and probabilistic modeling, especially in applications related to graph analysis and Gaussian models. It is not uncommon that positive definite matrices used in practice have special structures (e.g. diagonal), which can be exploited to accelerate computation.
 
 *PDMats.jl* supports efficient computation on positive definite matrices of various structures. In particular, it provides uniform interfaces to use positive definite matrices of various structures for writing generic algorithms, while ensuring that the most efficient implementation is used in actual computation.
 
@@ -14,7 +14,7 @@ Positive definite matrices are widely used in machine learning and probabilistic
 
 ## Positive definite matrix types
 
-This package defines an abstract type ``AbstractPDMat`` as the base type for positive definite matrices with different internal representations. 
+This package defines an abstract type ``AbstractPDMat`` as the base type for positive definite matrices with different internal representations.
 
 * ``PDMat``: full covariance matrix, defined as
 
@@ -37,7 +37,7 @@ PDMat(mat, uplo)    # with the input matrix, and an uplo argument (:U or :L)
                     # to specify the way Choleksy is done
 
 PDMat(chol)         # with the Cholesky factorization
-                    # Remarks: the full matrix will be computed upon 
+                    # Remarks: the full matrix will be computed upon
                     # construction.
 ```
 
@@ -79,7 +79,7 @@ All subtypes of ``AbstractPDMat`` share the same API, *i.e.* with the same set o
 
 ```julia
 
-dim(a)      # return the dimension of `a`. 
+dim(a)      # return the dimension of `a`.
             # Let `a` represent a d x d matrix, then `dim(a)` returns d.
 
 size(a)     # return the size tuple of `a`, i.e. `(dim(a), dim(a))`.
@@ -95,10 +95,10 @@ full(a)     # return a copy of the matrix in full form.
 diag(a)     # return a vector of diagonal elements.
 
 inv(a)      # inverse of `a`, of a proper subtype of `AbstractPDMat`.
-            # Note: when `a` is an instance of either `PDMat`, `PDiagMat`, 
-            # and `ScalMat`, `inv(a)` is of the same type of `a`. 
-            # This needs not be required for customized subtypes -- the 
-            # inverse does not always has the same pattern as `a`. 
+            # Note: when `a` is an instance of either `PDMat`, `PDiagMat`,
+            # and `ScalMat`, `inv(a)` is of the same type of `a`.
+            # This needs not be required for customized subtypes -- the
+            # inverse does not always has the same pattern as `a`.
 
 eigmax(a)   # maximum eigenvalue of `a`.
 
@@ -108,7 +108,7 @@ logdet(a)   # log-determinant of `a`, computed in a numerically stable way.
 
 a * x       # multiple `a` with `x` (forward transform)
 
-a \ x       # multiply `inv(a)` with `x` (backward transform). 
+a \ x       # multiply `inv(a)` with `x` (backward transform).
             # The internal implementation may not explicitly instantiate
             # the inverse of `a`.
 
@@ -119,7 +119,7 @@ c * a       # equivalent to a * c.
 
 a + b       # add two positive definite matrices
 
-pdadd(a, b, c)      # add `a` with `b * c`, where both `a` and `b` are 
+pdadd(a, b, c)      # add `a` with `b * c`, where both `a` and `b` are
                     # instances of `AbstractPDMat`.
 
 pdadd(m, a)         # add `a` to a dense matrix `m` of the same size.
@@ -134,7 +134,7 @@ pdadd!(m, a, c)     # add `a * c` to a dense matrix `m` of the same size,
 pdadd!(r, m, a)     # add `a` to a dense matrix `m` of the same size, and write
                     # the result to `r`.
 
-pdadd!(r, m, a, c)  # add `a * c` to a dense matrix `m` of the same size, and 
+pdadd!(r, m, a, c)  # add `a * c` to a dense matrix `m` of the same size, and
                     # write the result to `r`.
 
 quad(a, x)          # compute x' * a * x when `x` is a vector.
@@ -149,7 +149,7 @@ invquad(a, x)       # compute x' * inv(a) * x when `x` is a vector.
                     # perform such computation in a column-wise fashion, when
                     # `x` is a matrix, and return a vector of length `n`.
 
-invquad!(r, a, x)   # compute x' * inv(a) * x in a column-wise fashion, and 
+invquad!(r, a, x)   # compute x' * inv(a) * x in a column-wise fashion, and
                     # write the results to `r`.
 
 X_A_Xt(a, x)        # compute `x * a * x'` for a matrix `x`.
@@ -162,8 +162,8 @@ Xt_invA_X(a, x)     # compute `x' * inv(a) * x` for a matrix `x`.
 
 whiten(a, x)        # whitening transform. `x` can be a vector or a matrix.
                     #
-                    # Note: If the covariance of `x` is `a`, then the 
-                    # covariance of the transformed result is an identity 
+                    # Note: If the covariance of `x` is `a`, then the
+                    # covariance of the transformed result is an identity
                     # matrix.
 
 whiten!(a, x)       # whitening transform inplace, directly updating `x`.
@@ -173,7 +173,7 @@ whiten!(r, a, x)    # write the transformed result to `r`.
 unwhiten(a, x)      # inverse of whitening transform. `x` can be a vector or
                     # a matrix.
                     #
-                    # Note: If the covariance of `x` is an identity matrix, 
+                    # Note: If the covariance of `x` is an identity matrix,
                     # then the covariance of the transformed result is `a`.
                     # Note: the un-whitening transform is useful for
                     # generating Gaussian samples.
@@ -182,7 +182,7 @@ unwhiten!(a, x)     # un-whitening transform inplace, updating `x`.
 
 unwhiten!(r, a, x)  # write the transformed result to `r`.
 
-test_pdmat(a, amat)     # test the correctness of implementation, given an 
+test_pdmat(a, amat)     # test the correctness of implementation, given an
                         # instance of some sub-type of `AbstractPDMat`, and
                         # a corresponding full matrix.
                         #
@@ -202,11 +202,14 @@ In some situation, it is useful to define a customized subtype of `AbstractPDMat
 
 dim(a::M)       # return the dimension of `a`
 
-full(a::M)      # return a copy of the matrix in full form, of type 
+full(a::M)      # return a copy of the matrix in full form, of type
                 # ``Matrix{Float64}``.
 
 diag(a::M)      # return the vector of diagonal elements, of type
                 # ``Vector{Float64}``.
+
+pdadd!(m, a, c)     # add `a * c` to a dense matrix `m` of the same size
+                    # inplace.
 
 * (a::M, c::Float64)        # return a scaled version of `a`.
 
@@ -230,12 +233,12 @@ unwhiten!(r::DenseVecOrMat, a::M, x::DenseVecOrMat)  # un-whitening transform,
 
 quad(a::M, x::DenseVector)      # compute `x' * a * x`
 
-quad!(r::AbstractArray, a::M, x::DenseMatrix)   # compute `x' * a * x` in 
+quad!(r::AbstractArray, a::M, x::DenseMatrix)   # compute `x' * a * x` in
                                                 # a column-wise manner
 
 invquad(a::M, x::DenseVector)   # compute `x' * inv(a) * x`
 
-invquad!(r::AbstractArray, a::M, x::DenseMatrix) # compute `x' * inv(a) * x` 
+invquad!(r::AbstractArray, a::M, x::DenseMatrix) # compute `x' * inv(a) * x`
                                                  # in a column-wise manner
 
 X_A_Xt(a::M, x::DenseMatrix)        # compute `x * a * x'`
@@ -246,7 +249,3 @@ X_invA_Xt(a::M, x::DenseMatrix)     # compute `x * inv(a) * x'`
 
 Xt_invA_X(a::M, x::DenseMatrix)     # compute `x' * inv(a) * x`
 ```
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Uniform interface for positive definite matrices of various structures.
 [![Build Status](https://travis-ci.org/JuliaStats/PDMats.jl.png?branch=master)](https://travis-ci.org/JuliaStats/PDMats.jl)
+[![Coverage Status](https://img.shields.io/coveralls/JuliaStats/PDMats.jl.svg)](https://coveralls.io/r/JuliaStats/PDMats.jl?branch=master)
 
 --------------
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ScalMat(d, v)       # with dimension d and diagonal value v
 immutable PDSparseMat <: AbstractPDMat
     dim::Int                       # matrix dimension
     mat::SparseMatrixCSC{Float64}  # input matrix
-    chol::CholmodFactor{Float64}   # Cholesky factorization of mat
+    chol::CholTypeSparse           # Cholesky factorization of mat
 end
 
 # Constructors

--- a/README.md
+++ b/README.md
@@ -67,9 +67,33 @@ immutable ScalMat <: AbstractPDMat
     inv_value::Float64      # inv(value)
 end
 
+
 # Constructors
 
 ScalMat(d, v)       # with dimension d and diagonal value v
+```
+
+
+* ``PDSparseMat``: sparse covariance matrix, defined as
+
+```julia
+immutable PDSparseMat <: AbstractPDMat
+    dim::Int                       # matrix dimension
+    mat::SparseMatrixCSC{Float64}  # input matrix
+    chol::CholmodFactor{Float64}   # Cholesky factorization of mat
+end
+
+# Constructors
+
+PDSparseMat(mat, chol)    # with both the input matrix and a Cholesky factorization
+
+PDSparseMat(mat)          # with the sparse input matrix, of type SparseMatrixCSC{Float64}
+                          # Remarks: the Cholesky factorization will be computed
+                          # upon construction.
+
+PDSparseMat(chol)         # with the Cholesky factorization
+                          # Remarks: the sparse matrix 'mat' will be computed upon
+                          # construction.
 ```
 
 

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -9,6 +9,7 @@ module PDMats
         # Types
         AbstractPDMat,
         PDMat,
+        PDSparseMat,
         PDiagMat,
         ScalMat,
 
@@ -35,7 +36,7 @@ module PDMats
 
     import Base.BLAS: nrm2, axpy!, gemv!, gemm, gemm!, trmv, trmv!, trmm, trmm!
     import Base.LAPACK: trtrs!
-    import Base.LinAlg: A_ldiv_B!, A_mul_B!, A_mul_Bc!, A_rdiv_B!, A_rdiv_Bc!, Ac_ldiv_B!, Cholesky
+    import Base.LinAlg: A_ldiv_B!, A_mul_B!, A_mul_Bc!, A_rdiv_B!, A_rdiv_Bc!, Ac_ldiv_B!, Cholesky, CHOLMOD.CholmodFactor
 
 
     # The abstract base type
@@ -48,6 +49,7 @@ module PDMats
     include("utils.jl")
 
     include("pdmat.jl")
+    include("pdsparsemat.jl")
     include("pdiagmat.jl")
     include("scalmat.jl")
 

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -36,7 +36,7 @@ module PDMats
 
     import Base.BLAS: nrm2, axpy!, gemv!, gemm, gemm!, trmv, trmv!, trmm, trmm!
     import Base.LAPACK: trtrs!
-    import Base.LinAlg: A_ldiv_B!, A_mul_B!, A_mul_Bc!, A_rdiv_B!, A_rdiv_Bc!, Ac_ldiv_B!, Cholesky, CHOLMOD.CholmodFactor
+    import Base.LinAlg: A_ldiv_B!, A_mul_B!, A_mul_Bc!, A_rdiv_B!, A_rdiv_Bc!, Ac_ldiv_B!, Cholesky
 
 
     # The abstract base type

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -4,18 +4,28 @@
 + (a::PDMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
 + (a::PDiagMat, b::AbstractPDMat) = PDMat(_adddiag!(full(b), a.diag))
 + (a::ScalMat, b::AbstractPDMat) = PDMat(_adddiag!(full(b), a.value))
++ (a::PDSparseMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
 
 + (a::PDMat, b::PDMat) = PDMat(a.mat + b.mat)
 + (a::PDMat, b::PDiagMat) = PDMat(_adddiag(a.mat, b.diag))
 + (a::PDMat, b::ScalMat) = PDMat(_adddiag(a.mat, b.value))
++ (a::PDMat, b::PDSparseMat) = PDMat(a.mat + b.mat)
 
 + (a::PDiagMat, b::PDMat) = PDMat(_adddiag(b.mat, a.diag))
 + (a::PDiagMat, b::PDiagMat) = PDiagMat(a.diag + b.diag)
 + (a::PDiagMat, b::ScalMat) = PDiagMat(a.diag .+ b.value)
++ (a::PDiagMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.diag))
 
 + (a::ScalMat, b::PDMat) = PDMat(_adddiag(b.mat, a.value))
 + (a::ScalMat, b::PDiagMat) = PDiagMat(a.value .+ b.diag)
 + (a::ScalMat, b::ScalMat) = ScalMat(a.dim, a.value + b.value)
++ (a::ScalMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.value))
+
++ (a::PDSparseMat, b::PDMat) = PDMat(full(a) + b.mat)
++ (a::PDSparseMat, b::PDiagMat) = PDSparseMat(_adddiag(a.mat, b.diag))
++ (a::PDSparseMat, b::ScalMat) = PDSparseMat(_adddiag(a.mat, b.value))
++ (a::PDSparseMat, b::PDSparseMat) = PDSparseMat(a.mat + b.mat)
+
 
 # between pdmat and uniformscaling (multiple of identity)
 
@@ -25,15 +35,24 @@
 pdadd(a::PDMat, b::AbstractPDMat, c::Float64) = PDMat(a.mat + full(b * c))
 pdadd(a::PDiagMat, b::AbstractPDMat, c::Float64) = PDMat(_adddiag!(full(b * c), a.diag, 1.0))
 pdadd(a::ScalMat, b::AbstractPDMat, c::Float64) = PDMat(_adddiag!(full(b * c), a.value))
+pdadd(a::PDSparseMat, b::AbstractPDMat, c::Float64) = PDMat(a.mat + full(b * c))
 
 pdadd(a::PDMat, b::PDMat, c::Float64) = PDMat(a.mat + b.mat * c)
 pdadd(a::PDMat, b::PDiagMat, c::Float64) = PDMat(_adddiag(a.mat, b.diag, c))
 pdadd(a::PDMat, b::ScalMat, c::Float64) = PDMat(_adddiag(a.mat, b.value * c))
+pdadd(a::PDMat, b::PDSparseMat, c::Float64) = PDMat(a.mat + b.mat * c)
 
 pdadd(a::PDiagMat, b::PDMat, c::Float64) = PDMat(_adddiag!(b.mat * c, a.diag, 1.0))
 pdadd(a::PDiagMat, b::PDiagMat, c::Float64) = PDiagMat(a.diag + b.diag * c)
 pdadd(a::PDiagMat, b::ScalMat, c::Float64) = PDiagMat(a.diag .+ b.value * c)
+pdadd(a::PDiagMat, b::PDSparseMat, c::Float64) = PDSparseMat(_adddiag!(b.mat * c, a.diag, 1.0))
 
 pdadd(a::ScalMat, b::PDMat, c::Float64) = PDMat(_adddiag!(b.mat * c, a.value))
 pdadd(a::ScalMat, b::PDiagMat, c::Float64) = PDiagMat(a.value .+ b.diag * c)
 pdadd(a::ScalMat, b::ScalMat, c::Float64) = ScalMat(a.dim, a.value + b.value * c)
+pdadd(a::ScalMat, b::PDSparseMat, c::Float64) = PDSparseMat(_adddiag!(b.mat * c, a.value))
+
+pdadd(a::PDSparseMat, b::PDMat, c::Float64) = PDMat(a.mat + b.mat * c)
+pdadd(a::PDSparseMat, b::PDiagMat, c::Float64) = PDSparseMat(_adddiag(a.mat, b.diag, c))
+pdadd(a::PDSparseMat, b::ScalMat, c::Float64) = PDSparseMat(_adddiag(a.mat, b.value * c))
+pdadd(a::PDSparseMat, b::PDSparseMat, c::Float64) = PDSparseMat(a.mat + b.mat * c)

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -5,7 +5,11 @@ if VERSION >= v"0.4.0-dev+4370"
 
     typealias CholType Cholesky{Float64, Matrix{Float64}}
     chol_lower(a::Matrix{Float64}) = chol(a, Val{:L})
+
+    typealias CholTypeSparse Base.SparseMatrix.CHOLMOD.Factor{Float64}
 else
     typealias CholType Cholesky{Float64}
     chol_lower(a::Matrix{Float64}) = chol(a, :L)
+
+    typealias CholTypeSparse Base.LinAlg.CHOLMOD.CholmodFactor{Float64}
 end

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -1,0 +1,106 @@
+# Sparse positive definite matrix together with a Cholesky factorization object
+
+immutable PDSparseMat <: AbstractPDMat
+    dim::Int
+    mat::SparseMatrixCSC{Float64, Int64}
+    chol::CholmodFactor{Float64, Int64}
+end
+
+function PDSparseMat(mat::SparseMatrixCSC{Float64, Int64}, chol::CholmodFactor{Float64, Int64})
+    d = size(mat, 1)
+    size(chol, 1) == d ||
+        throw(DimensionMismatch("Dimensions of mat and chol are inconsistent."))
+    PDSparseMat(d, mat, chol)
+end
+
+PDSparseMat(mat::SparseMatrixCSC{Float64, Int64}) = PDSparseMat(mat, cholfact(mat))
+
+PDSparseMat(fac::CholmodFactor{Float64, Int64}) = PDSparseMat(size(fac,1), sparse(fac) |> x -> x*x', fac)
+
+### Basics
+
+dim(a::PDSparseMat) = a.dim
+full(a::PDSparseMat) = full(a.mat)
+diag(a::PDSparseMat) = diag(a.mat)
+
+
+### Arithmetics
+
+* (a::PDSparseMat, c::Float64) = PDSparseMat(a.mat * c)
+* (a::PDSparseMat, x::DenseVecOrMat) = a.mat * x
+\ (a::PDSparseMat, x::DenseVecOrMat) = a.chol \ x
+
+
+### Algebra
+
+inv(a::PDSparseMat) = PDMat( a\eye(a.dim) )
+logdet(a::PDSparseMat) = logdet(a.chol)
+eigmax(a::PDSparseMat) = maximum(eigs(a.mat, ritzvec = false)[1])
+eigmin(a::PDSparseMat) = minimum(eigs(a.mat, ritzvec = false)[1])
+
+
+### whiten and unwhiten
+
+function whiten!(r::DenseVecOrMat{Float64}, a::PDSparseMat, x::DenseVecOrMat{Float64})
+    A_ldiv_B!(a.chol, _rcopy!(r, x))
+    return r
+end
+
+
+function unwhiten!(r::DenseVecOrMat{Float64}, a::PDSparseMat, x::StridedVecOrMat{Float64})
+    r[:] = sparse(a.chol) * x
+    return r
+end
+
+
+### quadratic forms
+
+quad(a::PDSparseMat, x::DenseVector{Float64}) = dot(x, a * x)
+invquad(a::PDSparseMat, x::DenseVector{Float64}) = dot(x, a \ x)
+
+function quad!(r::AbstractArray, a::PDSparseMat, x::DenseMatrix{Float64})
+    for i in 1:size(x, 2)
+        r[i] = quad(a, x[:,i])
+    end
+end
+
+function invquad!(r::AbstractArray, a::PDSparseMat, x::DenseMatrix{Float64})
+    for i in 1:size(x, 2)
+        r[i] = invquad(a, x[:,i])
+    end
+end
+
+
+### tri products
+
+
+## function X_A_Xt(a::PDSparseMat, x::DenseMatrix{Float64})
+##     z = x*a.mat
+##     A_mul_Bt(z, X)
+## end
+
+function X_A_Xt(a::PDSparseMat, x::DenseMatrix{Float64})
+    z = x*sparse(a.chol)
+    A_mul_Bt(z, z)
+end
+
+## function Xt_A_X(a::PDSparseMat, x::DenseMatrix{Float64})
+##     z = a.mat*x
+##     At_mul_B(X, z)
+## end
+
+function Xt_A_X(a::PDSparseMat, x::DenseMatrix{Float64})
+    z = At_mul_B(x, sparse(a.chol))
+    A_mul_Bt(z, z)
+end
+
+
+function X_invA_Xt(a::PDSparseMat, x::DenseMatrix{Float64})
+    z = a \ x'
+    x * z
+end
+
+function Xt_invA_X(a::PDSparseMat, x::DenseMatrix{Float64})
+    z = a \ x
+    At_mul_B(x, z)
+end

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -2,10 +2,10 @@
 immutable PDSparseMat <: AbstractPDMat
     dim::Int
     mat::SparseMatrixCSC{Float64}
-    chol::CholmodFactor{Float64}
+    chol::CholTypeSparse
 end
 
-function PDSparseMat(mat::SparseMatrixCSC{Float64}, chol::CholmodFactor{Float64})
+function PDSparseMat(mat::SparseMatrixCSC{Float64}, chol::CholTypeSparse)
     d = size(mat, 1)
     size(chol, 1) == d ||
         throw(DimensionMismatch("Dimensions of mat and chol are inconsistent."))
@@ -14,7 +14,7 @@ end
 
 PDSparseMat(mat::SparseMatrixCSC{Float64}) = PDSparseMat(mat, cholfact(mat))
 
-PDSparseMat(fac::CholmodFactor{Float64}) = PDSparseMat(size(fac,1), sparse(fac) |> x -> x*x', fac)
+PDSparseMat(fac::CholTypeSparse) = PDSparseMat(size(fac,1), sparse(fac) |> x -> x*x', fac)
 
 ### Basics
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,7 +10,7 @@ end
 _rcopy!(r::DenseVecOrMat, x::DenseVecOrMat) = (is(r, x) || copy!(r, x); r)
 
 
-function _addscal!(r::Matrix, a::Matrix, b::Matrix, c::Real)
+function _addscal!(r::Matrix, a::Matrix, b::Union(Matrix, SparseMatrixCSC), c::Real)
     if c == 1.0
         for i = 1:length(a)
             @inbounds r[i] = a[i] + b[i]
@@ -76,4 +76,3 @@ function colwise_sumsq!(r::AbstractArray, a::DenseMatrix, c::Real)
     end
     return r
 end
-

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,7 +23,7 @@ function _addscal!(r::Matrix, a::Matrix, b::Union(Matrix, SparseMatrixCSC), c::R
     return r
 end
 
-function _adddiag!(a::Matrix, v::Real)
+function _adddiag!(a::Union(Matrix, SparseMatrixCSC), v::Real)
     n = size(a, 1)
     for i = 1:n
         @inbounds a[i,i] += v
@@ -31,7 +31,7 @@ function _adddiag!(a::Matrix, v::Real)
     return a
 end
 
-function _adddiag!(a::Matrix, v::Vector, c::Real)
+function _adddiag!(a::Union(Matrix, SparseMatrixCSC), v::Vector, c::Real)
     n = size(a, 1)
     @check_argdims length(v) == n
     if c == 1.0
@@ -46,9 +46,9 @@ function _adddiag!(a::Matrix, v::Vector, c::Real)
     return a
 end
 
-_adddiag(a::Matrix, v::Real) = _adddiag!(copy(a), v)
-_adddiag(a::Matrix, v::Vector, c::Real) = _adddiag!(copy(a), v, c)
-_adddiag(a::Matrix, v::Vector) = _adddiag!(copy(a), v, 1.0)
+_adddiag(a::Union(Matrix, SparseMatrixCSC), v::Real) = _adddiag!(copy(a), v)
+_adddiag(a::Union(Matrix, SparseMatrixCSC), v::Vector, c::Real) = _adddiag!(copy(a), v, c)
+_adddiag(a::Union(Matrix, SparseMatrixCSC), v::Vector) = _adddiag!(copy(a), v, 1.0)
 
 function wsumsq(w::AbstractVector, a::AbstractVector)
     @check_argdims(length(a) == length(w))

--- a/test/addition.jl
+++ b/test/addition.jl
@@ -10,6 +10,7 @@ pm1 = PDMat(C1)
 pm2 = PDiagMat(va)
 pm3 = ScalMat(3, 2.0)
 pm4 = 2.0I
+pm5 = PDSparseMat(sparse(C1))
 
 pmats = Any[pm1, pm2, pm3]
 

--- a/test/addition.jl
+++ b/test/addition.jl
@@ -12,7 +12,7 @@ pm3 = ScalMat(3, 2.0)
 pm4 = 2.0I
 pm5 = PDSparseMat(sparse(C1))
 
-pmats = Any[pm1, pm2, pm3]
+pmats = Any[pm1, pm2, pm3, pm5]
 
 for p1 in pmats, p2 in pmats
 	pr = p1 + p2

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -6,9 +6,10 @@ C1 = [4. -2. -1.; -2. 5. -1.; -1. -1. 6.]
 va = [1.5, 2.5, 2.0]
 
 for (C, Cmat, ceq) in Any[
-    (PDMat(C1), C1, true),
-    (PDiagMat(va), diagm(va), true),
-    (ScalMat(3, 2.0), 2.0 * eye(3, 3), true)
+                          (PDMat(C1), C1, true),
+                          (PDiagMat(va), diagm(va), true),
+                          (ScalMat(3, 2.0), 2.0 * eye(3, 3), true),
+                          (PDSparseMat(sparse(C1)), C1, true)
     ]
 
     test_pdmat(C, Cmat; cmat_eq=ceq, verbose=1)


### PR DESCRIPTION
A type and the required functions for sparse covariance matrices as mention in #23. However, I need some help with two points:
-  It passes the `test_pdmat` test, however, not the addition tests.  Should the addition methods be derived automatically or do we have to add the new methods in `addition.jl` manually?

- I'm not sure if all calculations in `pdsparsemat.jl` are done in the most efficient way.