### PR TITLE
Added __precompile__ flag to help with using on small-memory VMs.

### DIFF
--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -1,4 +1,4 @@
-__precompile__(true)
+VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 
 module PDMats
 

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -1,3 +1,5 @@
+__precompile__(true)
+
 module PDMats
 
     using ArrayViews


### PR DESCRIPTION
In trying to use Distributions.jl on an HPC cluster, I found that I need to precompile each of my dependencies one-by-one. Adding this flag allowed me to force a precompile on PDMats.jl so that the subsequent precompiles actually ran inside the memory limit.