### PR TITLE
Supportfloat32

### DIFF
--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -44,7 +44,7 @@ module PDMats
 
     # The abstract base type
 
-    abstract AbstractPDMat
+    abstract AbstractPDMat{T<:AbstractFloat}
 
     # source files
 

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -29,30 +29,30 @@
 
 # between pdmat and uniformscaling (multiple of identity)
 
-+(a::AbstractPDMat, b::UniformScaling) = a + ScalMat(dim(a), convert(Float64, b.λ))
-+(a::UniformScaling, b::AbstractPDMat) = ScalMat(dim(b), convert(Float64, a.λ)) + b
++(a::AbstractPDMat, b::UniformScaling) = a + ScalMat(dim(a), b.λ)
++(a::UniformScaling, b::AbstractPDMat) = ScalMat(dim(b), a.λ) + b
 
-pdadd(a::PDMat, b::AbstractPDMat, c::Float64) = PDMat(a.mat + full(b * c))
-pdadd(a::PDiagMat, b::AbstractPDMat, c::Float64) = PDMat(_adddiag!(full(b * c), a.diag, 1.0))
-pdadd(a::ScalMat, b::AbstractPDMat, c::Float64) = PDMat(_adddiag!(full(b * c), a.value))
-pdadd(a::PDSparseMat, b::AbstractPDMat, c::Float64) = PDMat(a.mat + full(b * c))
+pdadd(a::PDMat, b::AbstractPDMat, c::AbstractFloat) = PDMat(a.mat + full(b * c))
+pdadd(a::PDiagMat, b::AbstractPDMat, c::AbstractFloat) = PDMat(_adddiag!(full(b * c), a.diag, one(c)))
+pdadd(a::ScalMat, b::AbstractPDMat, c::AbstractFloat) = PDMat(_adddiag!(full(b * c), a.value))
+pdadd(a::PDSparseMat, b::AbstractPDMat, c::AbstractFloat) = PDMat(a.mat + full(b * c))
 
-pdadd(a::PDMat, b::PDMat, c::Float64) = PDMat(a.mat + b.mat * c)
-pdadd(a::PDMat, b::PDiagMat, c::Float64) = PDMat(_adddiag(a.mat, b.diag, c))
-pdadd(a::PDMat, b::ScalMat, c::Float64) = PDMat(_adddiag(a.mat, b.value * c))
-pdadd(a::PDMat, b::PDSparseMat, c::Float64) = PDMat(a.mat + b.mat * c)
+pdadd(a::PDMat, b::PDMat, c::AbstractFloat) = PDMat(a.mat + b.mat * c)
+pdadd(a::PDMat, b::PDiagMat, c::AbstractFloat) = PDMat(_adddiag(a.mat, b.diag, c))
+pdadd(a::PDMat, b::ScalMat, c::AbstractFloat) = PDMat(_adddiag(a.mat, b.value * c))
+pdadd(a::PDMat, b::PDSparseMat, c::AbstractFloat) = PDMat(a.mat + b.mat * c)
 
-pdadd(a::PDiagMat, b::PDMat, c::Float64) = PDMat(_adddiag!(b.mat * c, a.diag, 1.0))
-pdadd(a::PDiagMat, b::PDiagMat, c::Float64) = PDiagMat(a.diag + b.diag * c)
-pdadd(a::PDiagMat, b::ScalMat, c::Float64) = PDiagMat(a.diag .+ b.value * c)
-pdadd(a::PDiagMat, b::PDSparseMat, c::Float64) = PDSparseMat(_adddiag!(b.mat * c, a.diag, 1.0))
+pdadd(a::PDiagMat, b::PDMat, c::AbstractFloat) = PDMat(_adddiag!(b.mat * c, a.diag, one(c)))
+pdadd(a::PDiagMat, b::PDiagMat, c::AbstractFloat) = PDiagMat(a.diag + b.diag * c)
+pdadd(a::PDiagMat, b::ScalMat, c::AbstractFloat) = PDiagMat(a.diag .+ b.value * c)
+pdadd(a::PDiagMat, b::PDSparseMat, c::AbstractFloat) = PDSparseMat(_adddiag!(b.mat * c, a.diag, one(c)))
 
-pdadd(a::ScalMat, b::PDMat, c::Float64) = PDMat(_adddiag!(b.mat * c, a.value))
-pdadd(a::ScalMat, b::PDiagMat, c::Float64) = PDiagMat(a.value .+ b.diag * c)
-pdadd(a::ScalMat, b::ScalMat, c::Float64) = ScalMat(a.dim, a.value + b.value * c)
-pdadd(a::ScalMat, b::PDSparseMat, c::Float64) = PDSparseMat(_adddiag!(b.mat * c, a.value))
+pdadd(a::ScalMat, b::PDMat, c::AbstractFloat) = PDMat(_adddiag!(b.mat * c, a.value))
+pdadd(a::ScalMat, b::PDiagMat, c::AbstractFloat) = PDiagMat(a.value .+ b.diag * c)
+pdadd(a::ScalMat, b::ScalMat, c::AbstractFloat) = ScalMat(a.dim, a.value + b.value * c)
+pdadd(a::ScalMat, b::PDSparseMat, c::AbstractFloat) = PDSparseMat(_adddiag!(b.mat * c, a.value))
 
-pdadd(a::PDSparseMat, b::PDMat, c::Float64) = PDMat(a.mat + b.mat * c)
-pdadd(a::PDSparseMat, b::PDiagMat, c::Float64) = PDSparseMat(_adddiag(a.mat, b.diag, c))
-pdadd(a::PDSparseMat, b::ScalMat, c::Float64) = PDSparseMat(_adddiag(a.mat, b.value * c))
-pdadd(a::PDSparseMat, b::PDSparseMat, c::Float64) = PDSparseMat(a.mat + b.mat * c)
+pdadd(a::PDSparseMat, b::PDMat, c::AbstractFloat) = PDMat(a.mat + b.mat * c)
+pdadd(a::PDSparseMat, b::PDiagMat, c::AbstractFloat) = PDSparseMat(_adddiag(a.mat, b.diag, c))
+pdadd(a::PDSparseMat, b::ScalMat, c::AbstractFloat) = PDSparseMat(_adddiag(a.mat, b.value * c))
+pdadd(a::PDSparseMat, b::PDSparseMat, c::AbstractFloat) = PDSparseMat(a.mat + b.mat * c)

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -1,26 +1,26 @@
 # needs special attention to Cholesky, as the syntax & behavior changes in 0.4-pre
 
 if VERSION >= v"0.5.0-dev+907"
-    typealias CholType Cholesky{Float64, Matrix{Float64}}
-    chol_lower(a::Matrix{Float64}) = ctranspose(chol(a))
+    typealias CholType{T,S<:AbstractMatrix} Cholesky{T,S}
+    chol_lower(a::Matrix) = ctranspose(chol(a))
 
-    typealias CholTypeSparse SparseArrays.CHOLMOD.Factor{Float64}
+    typealias CholTypeSparse{T} SparseArrays.CHOLMOD.Factor{T}
 
     chol_lower(cf::CholTypeSparse) = cf[:L]
 elseif VERSION >= v"0.4.0-dev+4370"
     # error("Choleksy changes in 0.4.0-dev+4370 (PR #10862), we are still working to make it work with these changes.")
 
-    typealias CholType Cholesky{Float64, Matrix{Float64}}
-    chol_lower(a::Matrix{Float64}) = chol(a, Val{:L})
+    typealias CholType{T,S<:AbstractMatrix} Cholesky{T,S}
+    chol_lower(a::Matrix) = chol(a, Val{:L})
 
-    typealias CholTypeSparse SparseArrays.CHOLMOD.Factor{Float64}
+    typealias CholTypeSparse{T} SparseArrays.CHOLMOD.Factor{T}
 
     chol_lower(cf::CholTypeSparse) = cf[:L]
 else
-    typealias CholType Cholesky{Float64}
-    chol_lower(a::Matrix{Float64}) = chol(a, :L)
+    typealias CholType{T,S} Cholesky{T}
+    chol_lower(a::Matrix) = chol(a, :L)
 
-    typealias CholTypeSparse Base.LinAlg.CHOLMOD.CholmodFactor{Float64}
+    typealias CholTypeSparse{T} Base.LinAlg.CHOLMOD.CholmodFactor{T}
 
     chol_lower(cf::CholTypeSparse) = cf
 end

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -3,17 +3,17 @@
 import Base: depwarn
 
 function add!(a::Matrix, b::AbstractPDMat)
-    depwarn("add! is deprecated in favor of pdadd!", :add!) 
+    depwarn("add! is deprecated in favor of pdadd!", :add!)
     pdadd!(a, b)
 end
 
 function add_scal!(a::Matrix, b::AbstractPDMat, c::Real)
-    depwarn("add! is deprecated in favor of pdadd!", :add_scal!) 
+    depwarn("add! is deprecated in favor of pdadd!", :add_scal!)
     pdadd!(a, b, c)
 end
 
 function add_scal(a::Matrix, b::AbstractPDMat, c::Real)
-    depwarn("add_scal is deprecated in favor of pdadd", :add_scal) 
+    depwarn("add_scal is deprecated in favor of pdadd", :add_scal)
     pdadd(a, b, c)
 end
 

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -2,7 +2,7 @@
 
 ## Basic functions
 
-Base.eltype(a::AbstractPDMat) = Float64
+Base.eltype{T<:AbstractFloat}(a::AbstractPDMat{T}) = T
 Base.ndims(a::AbstractPDMat) = 2
 Base.size(a::AbstractPDMat) = (dim(a), dim(a))
 Base.size(a::AbstractPDMat, i::Integer) = 1 <= i <= 2 ? dim(a) : 1
@@ -10,39 +10,39 @@ Base.length(a::AbstractPDMat) = abs2(dim(a))
 
 ## arithmetics
 
-pdadd!(r::Matrix{Float64}, a::Matrix{Float64}, b::AbstractPDMat) = pdadd!(r, a, b, 1.0)
+pdadd!{T<:AbstractFloat}(r::Matrix{T}, a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(r, a, b, one(T))
 
-pdadd!(a::Matrix{Float64}, b::AbstractPDMat, c::Real) = pdadd!(a, a, b, convert(Float64, c))
-pdadd!(a::Matrix{Float64}, b::AbstractPDMat) = pdadd!(a, a, b, 1.0)
+pdadd!{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}, c::T) = pdadd!(a, a, b, c)
+pdadd!{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(a, a, b, one(T))
 
-pdadd(a::Matrix{Float64}, b::AbstractPDMat, c::Real) = pdadd!(similar(a), a, b, convert(Float64, c))
-pdadd(a::Matrix{Float64}, b::AbstractPDMat) = pdadd!(similar(a), a, b, 1.0)
+pdadd{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}, c::T) = pdadd!(similar(a), a, b, c)
+pdadd{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(similar(a), a, b, one(T))
 
-+(a::Matrix{Float64}, b::AbstractPDMat) = pdadd(a, b)
-+(a::AbstractPDMat, b::Matrix{Float64}) = pdadd(b, a)
++{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}) = pdadd(a, b)
++{T<:AbstractFloat}(a::AbstractPDMat{T}, b::Matrix{T}) = pdadd(b, a)
 
-*(a::AbstractPDMat, c::Real) = a * convert(Float64, c)
-*(c::Real, a::AbstractPDMat) = a * convert(Float64, c)
-/(a::AbstractPDMat, c::Real) = a * convert(Float64, inv(c))
+*{T<:AbstractFloat}(a::AbstractPDMat{T}, c::T) = a * c
+*{T<:AbstractFloat}(c::T, a::AbstractPDMat{T}) = a * c
+/{T<:AbstractFloat}(a::AbstractPDMat{T}, c::T) = a * inv(c)
 
 
 ## whiten and unwhiten
 
-whiten!(a::AbstractPDMat, x::DenseVecOrMat{Float64}) = whiten!(x, a, x)
-unwhiten!(a::AbstractPDMat, x::DenseVecOrMat{Float64}) = unwhiten!(x, a, x)
+whiten!{T<:AbstractFloat}(a::AbstractPDMat{T}, x::DenseVecOrMat{T}) = whiten!(x, a, x)
+unwhiten!{T<:AbstractFloat}(a::AbstractPDMat{T}, x::DenseVecOrMat{T}) = unwhiten!(x, a, x)
 
-whiten(a::AbstractPDMat, x::DenseVecOrMat{Float64}) = whiten!(similar(x), a, x)
-unwhiten(a::AbstractPDMat, x::DenseVecOrMat{Float64}) = unwhiten!(similar(x), a, x)
+whiten{T<:AbstractFloat}(a::AbstractPDMat{T}, x::DenseVecOrMat{T}) = whiten!(similar(x), a, x)
+unwhiten{T<:AbstractFloat}(a::AbstractPDMat{T}, x::DenseVecOrMat{T}) = unwhiten!(similar(x), a, x)
 
 
 ## quad
 
-function quad(a::AbstractPDMat, x::DenseMatrix{Float64})
+function quad{T<:AbstractFloat}(a::AbstractPDMat{T}, x::DenseMatrix{T})
     @check_argdims dim(a) == size(x, 1)
-    quad!(Array(Float64, size(x,2)), a, x)
+    quad!(Array(T, size(x,2)), a, x)
 end
 
-function invquad(a::AbstractPDMat, x::DenseMatrix{Float64})
+function invquad{T<:AbstractFloat}(a::AbstractPDMat{T}, x::DenseMatrix{T})
     @check_argdims dim(a) == size(x, 1)
-    invquad!(Array(Float64, size(x,2)), a, x)
+    invquad!(Array(T, size(x,2)), a, x)
 end

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -1,17 +1,18 @@
 # positive diagonal matrix
 
-immutable PDiagMat <: AbstractPDMat
-    dim::Int
-    diag::Vector{Float64}
-    inv_diag::Vector{Float64}
-
-    PDiagMat(v::Vector{Float64}) = new(length(v), v, 1.0 ./ v)
-
-    function PDiagMat(v::Vector{Float64}, inv_v::Vector{Float64})
-        @check_argdims length(v) == length(inv_v)
-        new(length(v), v, inv_v)
-    end
+immutable PDiagMat{T<:AbstractFloat,V<:AbstractVector} <: AbstractPDMat{T}
+  dim::Int
+  diag::V
+  inv_diag::V
+  PDiagMat(d::Int,v::AbstractVector{T},inv_v::AbstractVector{T}) = new(d,v,inv_v)
 end
+
+function PDiagMat(v::AbstractVector,inv_v::AbstractVector)
+  @check_argdims length(v) == length(inv_v)
+  PDiagMat{eltype(v),typeof(v)}(length(v), v, inv_v)
+end
+
+PDiagMat(v::Vector) = PDiagMat(v, ones(v)./v)
 
 
 ### Basics
@@ -23,19 +24,19 @@ diag(a::PDiagMat) = copy(a.diag)
 
 ### Arithmetics
 
-function pdadd!(r::Matrix{Float64}, a::Matrix{Float64}, b::PDiagMat, c::Real)
+function pdadd!{T<:AbstractFloat}(r::Matrix{T}, a::Matrix{T}, b::PDiagMat{T}, c::T)
     @check_argdims size(r) == size(a) == size(b)
     if is(r, a)
-        _adddiag!(r, b.diag, convert(Float64, c))
+        _adddiag!(r, b.diag, c)
     else
-        _adddiag!(copy!(r, a), b.diag, convert(Float64, c))
+        _adddiag!(copy!(r, a), b.diag, c)
     end
     return r
 end
 
-*(a::PDiagMat, c::Float64) = PDiagMat(a.diag * c)
-*(a::PDiagMat, x::DenseVecOrMat) = a.diag .* x
-\(a::PDiagMat, x::DenseVecOrMat) = a.inv_diag .* x
+*{T<:AbstractFloat}(a::PDiagMat{T}, c::T) = PDiagMat(a.diag * c)
+*{T<:AbstractFloat}(a::PDiagMat{T}, x::DenseVecOrMat{T}) = a.diag .* x
+\{T<:AbstractFloat}(a::PDiagMat{T}, x::DenseVecOrMat{T}) = a.inv_diag .* x
 
 
 ### Algebra
@@ -48,7 +49,7 @@ eigmin(a::PDiagMat) = minimum(a.diag)
 
 ### whiten and unwhiten
 
-function whiten!(r::DenseVector{Float64}, a::PDiagMat, x::DenseVector{Float64})
+function whiten!{T<:AbstractFloat}(r::DenseVector{T}, a::PDiagMat{T}, x::DenseVector{T})
     n = dim(a)
     @check_argdims length(r) == length(x) == n
     v = a.inv_diag
@@ -58,7 +59,7 @@ function whiten!(r::DenseVector{Float64}, a::PDiagMat, x::DenseVector{Float64})
     return r
 end
 
-function unwhiten!(r::DenseVector{Float64}, a::PDiagMat, x::DenseVector{Float64})
+function unwhiten!{T<:AbstractFloat}(r::DenseVector{T}, a::PDiagMat{T}, x::DenseVector{T})
     n = dim(a)
     @check_argdims length(r) == length(x) == n
     v = a.diag
@@ -68,40 +69,40 @@ function unwhiten!(r::DenseVector{Float64}, a::PDiagMat, x::DenseVector{Float64}
     return r
 end
 
-whiten!(r::DenseMatrix{Float64}, a::PDiagMat, x::DenseMatrix{Float64}) =
+whiten!{T<:AbstractFloat}(r::DenseMatrix{T}, a::PDiagMat{T}, x::DenseMatrix{T}) =
     broadcast!(*, r, x, sqrt(a.inv_diag))
 
-unwhiten!(r::DenseMatrix{Float64}, a::PDiagMat, x::DenseMatrix{Float64}) =
+unwhiten!{T<:AbstractFloat}(r::DenseMatrix{T}, a::PDiagMat{T}, x::DenseMatrix{T}) =
     broadcast!(*, r, x, sqrt(a.diag))
 
 
 ### quadratic forms
 
-quad(a::PDiagMat, x::Vector{Float64}) = wsumsq(a.diag, x)
-invquad(a::PDiagMat, x::Vector{Float64}) = wsumsq(a.inv_diag, x)
+quad{T<:AbstractFloat}(a::PDiagMat{T}, x::Vector{T}) = wsumsq(a.diag, x)
+invquad{T<:AbstractFloat}(a::PDiagMat{T}, x::Vector{T}) = wsumsq(a.inv_diag, x)
 
-quad!(r::AbstractArray, a::PDiagMat, x::Matrix{Float64}) = At_mul_B!(r, abs2(x), a.diag)
-invquad!(r::AbstractArray, a::PDiagMat, x::Matrix{Float64}) = At_mul_B!(r, abs2(x), a.inv_diag)
+quad!{T<:AbstractFloat}(r::AbstractArray{T}, a::PDiagMat{T}, x::Matrix{T}) = At_mul_B!(r, abs2(x), a.diag)
+invquad!{T<:AbstractFloat}(r::AbstractArray{T}, a::PDiagMat{T}, x::Matrix{T}) = At_mul_B!(r, abs2(x), a.inv_diag)
 
 
 ### tri products
 
-function X_A_Xt(a::PDiagMat, x::DenseMatrix{Float64})
+function X_A_Xt{T<:AbstractFloat}(a::PDiagMat{T}, x::DenseMatrix{T})
     z = x .* reshape(sqrt(a.diag), 1, dim(a))
     A_mul_Bt(z, z)
 end
 
-function Xt_A_X(a::PDiagMat, x::DenseMatrix{Float64})
+function Xt_A_X{T<:AbstractFloat}(a::PDiagMat{T}, x::DenseMatrix{T})
     z = x .* sqrt(a.diag)
     At_mul_B(z, z)
 end
 
-function X_invA_Xt(a::PDiagMat, x::DenseMatrix{Float64})
+function X_invA_Xt{T<:AbstractFloat}(a::PDiagMat{T}, x::DenseMatrix{T})
     z = x .* reshape(sqrt(a.inv_diag), 1, dim(a))
     A_mul_Bt(z, z)
 end
 
-function Xt_invA_X(a::PDiagMat, x::DenseMatrix{Float64})
+function Xt_invA_X{T<:AbstractFloat}(a::PDiagMat{T}, x::DenseMatrix{T})
     z = x .* sqrt(a.inv_diag)
     At_mul_B(z, z)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,8 +10,8 @@ end
 _rcopy!(r::DenseVecOrMat, x::DenseVecOrMat) = (is(r, x) || copy!(r, x); r)
 
 
-@compat function _addscal!(r::Matrix, a::Matrix, b::Union{Matrix, SparseMatrixCSC}, c::Real)
-    if c == 1.0
+@compat function _addscal!{T<:AbstractFloat}(r::Matrix{T}, a::Matrix{T}, b::Union{Matrix{T}, SparseMatrixCSC{T}}, c::T)
+    if c == one(T)
         for i = 1:length(a)
             @inbounds r[i] = a[i] + b[i]
         end
@@ -23,7 +23,7 @@ _rcopy!(r::DenseVecOrMat, x::DenseVecOrMat) = (is(r, x) || copy!(r, x); r)
     return r
 end
 
-@compat function _adddiag!(a::Union{Matrix, SparseMatrixCSC}, v::Real)
+@compat function _adddiag!{T<:AbstractFloat}(a::Union{Matrix{T}, SparseMatrixCSC{T}}, v::T)
     n = size(a, 1)
     for i = 1:n
         @inbounds a[i,i] += v
@@ -31,10 +31,10 @@ end
     return a
 end
 
-@compat function _adddiag!(a::Union{Matrix, SparseMatrixCSC}, v::Vector, c::Real)
+@compat function _adddiag!{T<:AbstractFloat}(a::Union{Matrix{T}, SparseMatrixCSC{T}}, v::Vector{T}, c::T)
     n = size(a, 1)
     @check_argdims length(v) == n
-    if c == 1.0
+    if c == one(T)
         for i = 1:n
             @inbounds a[i,i] += v[i]
         end
@@ -46,20 +46,20 @@ end
     return a
 end
 
-@compat _adddiag(a::Union{Matrix, SparseMatrixCSC}, v::Real) = _adddiag!(copy(a), v)
-@compat _adddiag(a::Union{Matrix, SparseMatrixCSC}, v::Vector, c::Real) = _adddiag!(copy(a), v, c)
-@compat _adddiag(a::Union{Matrix, SparseMatrixCSC}, v::Vector) = _adddiag!(copy(a), v, 1.0)
+@compat _adddiag{T<:AbstractFloat}(a::Union{Matrix{T}, SparseMatrixCSC{T}}, v::T) = _adddiag!(copy(a), v)
+@compat _adddiag{T<:AbstractFloat}(a::Union{Matrix{T}, SparseMatrixCSC{T}}, v::Vector{T}, c::T) = _adddiag!(copy(a), v, c)
+@compat _adddiag{T<:AbstractFloat}(a::Union{Matrix{T}, SparseMatrixCSC{T}}, v::Vector{T}) = _adddiag!(copy(a), v, one(T))
 
-function wsumsq(w::AbstractVector, a::AbstractVector)
+function wsumsq{T<:AbstractFloat}(w::AbstractVector{T}, a::AbstractVector{T})
     @check_argdims(length(a) == length(w))
-    s = 0.
+    s = zero(T)
     for i = 1:length(a)
         @inbounds s += abs2(a[i]) * w[i]
     end
     return s
 end
 
-function colwise_dot!(r::AbstractArray, a::DenseMatrix, b::DenseMatrix)
+function colwise_dot!{T<:AbstractFloat}(r::AbstractArray{T}, a::DenseMatrix{T}, b::DenseMatrix{T})
     n = length(r)
     @check_argdims n == size(a, 2) == size(b, 2) && size(a, 1) == size(b, 1)
     for i = 1:n
@@ -68,7 +68,7 @@ function colwise_dot!(r::AbstractArray, a::DenseMatrix, b::DenseMatrix)
     return r
 end
 
-function colwise_sumsq!(r::AbstractArray, a::DenseMatrix, c::Real)
+function colwise_sumsq!{T<:AbstractFloat}(r::AbstractArray{T}, a::DenseMatrix{T}, c::T)
     n = length(r)
     @check_argdims n == size(a, 2)
     for i = 1:n

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -1,16 +1,25 @@
 # test pd matrix types
-
 using PDMats
+using Base.Test
 
-C1 = [4. -2. -1.; -2. 5. -1.; -1. -1. 6.]
-va = [1.5, 2.5, 2.0]
+call_test_pdmat(p::AbstractPDMat,m::Matrix) = test_pdmat(p,m,cmat_eq=true,verbose=1)
 
-for (C, Cmat, ceq) in Any[
-                          (PDMat(C1), C1, true),
-                          (PDiagMat(va), diagm(va), true),
-                          (ScalMat(3, 2.0), 2.0 * eye(3, 3), true),
-                          (PDSparseMat(sparse(C1)), C1, true)
-    ]
+for T in [Float64,Float32]
+  #test that all external constructors are accessible
+  m = eye(T,2) ; @test PDMat(m,cholfact(m)).mat == PDMat(Symmetric(m)).mat == PDMat(m).mat == PDMat(cholfact(m)).mat
+  d = ones(T,2) ; @test PDiagMat(d,d).inv_diag == PDiagMat(d).inv_diag
+  x = one(T) ; @test ScalMat(2,x,x).inv_value == ScalMat(2,x).inv_value
+  #for Julia v0.3, do not test sparse matrices with Float32 (see issue #14076)
+  (T == Float64 || VERSION >= v"0.4.2") && (s = speye(T,2,2) ; @test PDSparseMat(s,cholfact(s)).mat == PDSparseMat(s).mat == PDSparseMat(cholfact(s)).mat)
 
-    test_pdmat(C, Cmat; cmat_eq=ceq, verbose=1)
+  #test the functionality
+  M = convert(Array{T,2},[4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
+  V = convert(Array{T,1},[1.5, 2.5, 2.0])
+  X = convert(T,2.0)
+
+  call_test_pdmat(PDMat(M),M) #tests of PDMat
+  call_test_pdmat(PDiagMat(V),diagm(V)) #tests of PDiagMat
+  call_test_pdmat(ScalMat(3,x),x*eye(T,3)) #tests of ScalMat
+  #for Julia v0.3, do not test sparse matrices with Float32 (see issue #14076)
+  (T == Float64 || VERSION >= v"0.4.2") && call_test_pdmat(PDSparseMat(sparse(M)),M)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,3 @@
-
-
-
 tests = ["pdmtypes", "addition"]
 println("Running tests ...")
 


### PR DESCRIPTION
I've made PDMats typed on T<:AbstractFloat and removed all hard-coded references to Float64. 

It's all working cleanly for PDMat, PDDiagMat and ScalMat. A few workarounds of existing problems were needed to get it to work with PDSparseMat.

Reason why I did this is so that in the Distributions.jl package it will be easier to allow distributions to generate different floating types (for instance, the multi-variate normal function uses PDMat internally).

Can someone review and let me know if this is good to be merged into the main branch?