### PR TITLE
Rewrite colwise_dot! and colwise_sumsq! to use explict loops

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.3
-ArrayViews 0.4.8-
 Compat 0.7.7

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -2,7 +2,6 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 
 module PDMats
 
-    using ArrayViews
     using Compat
 
     import Base: +, *, \, /, ==

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,20 +59,28 @@ function wsumsq{T<:AbstractFloat}(w::AbstractVector{T}, a::AbstractVector{T})
     return s
 end
 
-function colwise_dot!{T<:AbstractFloat}(r::AbstractArray{T}, a::DenseMatrix{T}, b::DenseMatrix{T})
+function colwise_dot!{T<:AbstractFloat}(r::AbstractArray{T}, a::AbstractMatrix{T}, b::AbstractMatrix{T})
     n = length(r)
     @check_argdims n == size(a, 2) == size(b, 2) && size(a, 1) == size(b, 1)
-    for i = 1:n
-        r[i] = dot(view(a,:,i), view(b,:,i))
+    for j = 1:n
+        v = zero(T)
+        @simd for i = 1:size(a, 1)
+            @inbounds v += a[i, j]*b[i, j]
+        end
+        r[j] = v
     end
     return r
 end
 
-function colwise_sumsq!{T<:AbstractFloat}(r::AbstractArray{T}, a::DenseMatrix{T}, c::T)
+function colwise_sumsq!{T<:AbstractFloat}(r::AbstractArray{T}, a::AbstractMatrix{T}, c::T)
     n = length(r)
     @check_argdims n == size(a, 2)
-    for i = 1:n
-        r[i] = sumabs2(view(a,:,i)) * c
+    for j = 1:n
+        v = zero(T)
+        @simd for i = 1:size(a, 1)
+            @inbounds v += abs2(a[i, j])
+        end
+        r[j] = v*c
     end
     return r
 end


### PR DESCRIPTION
For small to moderately sized covariance matrices, the time cost of allocating these views can be pretty big. This was also the only place this package used ArrayViews.