### PR TITLE
generalize pdmats to work with ForwardDiff

### DIFF
--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -43,7 +43,7 @@ module PDMats
 
     # The abstract base type
 
-    abstract AbstractPDMat{T<:AbstractFloat}
+    abstract AbstractPDMat{T<:Real}
 
     # source files
 

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -2,7 +2,7 @@
 
 ## Basic functions
 
-Base.eltype{T<:AbstractFloat}(a::AbstractPDMat{T}) = T
+Base.eltype{T<:Real}(a::AbstractPDMat{T}) = T
 Base.ndims(a::AbstractPDMat) = 2
 Base.size(a::AbstractPDMat) = (dim(a), dim(a))
 Base.size(a::AbstractPDMat, i::Integer) = 1 <= i <= 2 ? dim(a) : 1
@@ -10,39 +10,39 @@ Base.length(a::AbstractPDMat) = abs2(dim(a))
 
 ## arithmetics
 
-pdadd!{T<:AbstractFloat}(r::Matrix{T}, a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(r, a, b, one(T))
+pdadd!{T<:Real}(r::Matrix{T}, a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(r, a, b, one(T))
 
-pdadd!{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}, c::T) = pdadd!(a, a, b, c)
-pdadd!{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(a, a, b, one(T))
+pdadd!(a::Matrix, b::AbstractPDMat, c) = pdadd!(a, a, b, c)
+pdadd!{T<:Real}(a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(a, a, b, one(T))
 
-pdadd{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}, c::T) = pdadd!(similar(a), a, b, c)
-pdadd{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(similar(a), a, b, one(T))
+pdadd(a::Matrix, b::AbstractPDMat, c) = pdadd!(similar(a), a, b, c)
+pdadd{T<:Real}(a::Matrix{T}, b::AbstractPDMat{T}) = pdadd!(similar(a), a, b, one(T))
 
-+{T<:AbstractFloat}(a::Matrix{T}, b::AbstractPDMat{T}) = pdadd(a, b)
-+{T<:AbstractFloat}(a::AbstractPDMat{T}, b::Matrix{T}) = pdadd(b, a)
++(a::Matrix, b::AbstractPDMat) = pdadd(a, b)
++(a::AbstractPDMat, b::Matrix) = pdadd(b, a)
 
-*{T<:AbstractFloat}(a::AbstractPDMat{T}, c::T) = a * c
-*{T<:AbstractFloat}(c::T, a::AbstractPDMat{T}) = a * c
-/{T<:AbstractFloat}(a::AbstractPDMat{T}, c::T) = a * inv(c)
+*{T<:Real}(a::AbstractPDMat{T}, c::T) = a * c
+*{T<:Real}(c::T, a::AbstractPDMat) = a * c
+/{T<:Real}(a::AbstractPDMat, c::T) = a * inv(c)
 
 
 ## whiten and unwhiten
 
-whiten!{T<:AbstractFloat}(a::AbstractPDMat{T}, x::StridedVecOrMat{T}) = whiten!(x, a, x)
-unwhiten!{T<:AbstractFloat}(a::AbstractPDMat{T}, x::StridedVecOrMat{T}) = unwhiten!(x, a, x)
+whiten!(a::AbstractPDMat, x::StridedVecOrMat) = whiten!(x, a, x)
+unwhiten!(a::AbstractPDMat, x::StridedVecOrMat) = unwhiten!(x, a, x)
 
-whiten{T<:AbstractFloat}(a::AbstractPDMat{T}, x::StridedVecOrMat{T}) = whiten!(similar(x), a, x)
-unwhiten{T<:AbstractFloat}(a::AbstractPDMat{T}, x::StridedVecOrMat{T}) = unwhiten!(similar(x), a, x)
+whiten(a::AbstractPDMat, x::StridedVecOrMat) = whiten!(similar(x), a, x)
+unwhiten(a::AbstractPDMat, x::StridedVecOrMat) = unwhiten!(similar(x), a, x)
 
 
 ## quad
 
-function quad{T<:AbstractFloat}(a::AbstractPDMat{T}, x::StridedMatrix{T})
+function quad{T<:Real}(a::AbstractPDMat{T}, x::StridedMatrix{T})
     @check_argdims dim(a) == size(x, 1)
     quad!(Array(T, size(x,2)), a, x)
 end
 
-function invquad{T<:AbstractFloat}(a::AbstractPDMat{T}, x::StridedMatrix{T})
+function invquad{T<:Real}(a::AbstractPDMat{T}, x::StridedMatrix{T})
     @check_argdims dim(a) == size(x, 1)
     invquad!(Array(T, size(x,2)), a, x)
 end

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -1,6 +1,6 @@
 # positive diagonal matrix
 
-immutable PDiagMat{T<:AbstractFloat,V<:AbstractVector} <: AbstractPDMat{T}
+immutable PDiagMat{T<:Real,V<:AbstractVector} <: AbstractPDMat{T}
   dim::Int
   diag::V
   inv_diag::V
@@ -24,7 +24,7 @@ diag(a::PDiagMat) = copy(a.diag)
 
 ### Arithmetics
 
-function pdadd!{T<:AbstractFloat}(r::Matrix{T}, a::Matrix{T}, b::PDiagMat{T}, c::T)
+function pdadd!(r::Matrix, a::Matrix, b::PDiagMat, c)
     @check_argdims size(r) == size(a) == size(b)
     if is(r, a)
         _adddiag!(r, b.diag, c)
@@ -34,9 +34,9 @@ function pdadd!{T<:AbstractFloat}(r::Matrix{T}, a::Matrix{T}, b::PDiagMat{T}, c:
     return r
 end
 
-*{T<:AbstractFloat}(a::PDiagMat{T}, c::T) = PDiagMat(a.diag * c)
-*{T<:AbstractFloat}(a::PDiagMat{T}, x::StridedVecOrMat{T}) = a.diag .* x
-\{T<:AbstractFloat}(a::PDiagMat{T}, x::StridedVecOrMat{T}) = a.inv_diag .* x
+*{T<:Real}(a::PDiagMat, c::T) = PDiagMat(a.diag * c)
+*(a::PDiagMat, x::StridedVecOrMat) = a.diag .* x
+\(a::PDiagMat, x::StridedVecOrMat) = a.inv_diag .* x
 
 
 ### Algebra
@@ -49,7 +49,7 @@ eigmin(a::PDiagMat) = minimum(a.diag)
 
 ### whiten and unwhiten
 
-function whiten!{T<:AbstractFloat}(r::StridedVector{T}, a::PDiagMat{T}, x::StridedVector{T})
+function whiten!(r::StridedVector, a::PDiagMat, x::StridedVector)
     n = dim(a)
     @check_argdims length(r) == length(x) == n
     v = a.inv_diag
@@ -59,7 +59,7 @@ function whiten!{T<:AbstractFloat}(r::StridedVector{T}, a::PDiagMat{T}, x::Strid
     return r
 end
 
-function unwhiten!{T<:AbstractFloat}(r::StridedVector{T}, a::PDiagMat{T}, x::StridedVector{T})
+function unwhiten!(r::StridedVector, a::PDiagMat, x::StridedVector)
     n = dim(a)
     @check_argdims length(r) == length(x) == n
     v = a.diag
@@ -69,40 +69,40 @@ function unwhiten!{T<:AbstractFloat}(r::StridedVector{T}, a::PDiagMat{T}, x::Str
     return r
 end
 
-whiten!{T<:AbstractFloat}(r::StridedMatrix{T}, a::PDiagMat{T}, x::StridedMatrix{T}) =
+whiten!(r::StridedMatrix, a::PDiagMat, x::StridedMatrix) =
     broadcast!(*, r, x, sqrt(a.inv_diag))
 
-unwhiten!{T<:AbstractFloat}(r::StridedMatrix{T}, a::PDiagMat{T}, x::StridedMatrix{T}) =
+unwhiten!(r::StridedMatrix, a::PDiagMat, x::StridedMatrix) =
     broadcast!(*, r, x, sqrt(a.diag))
 
 
 ### quadratic forms
 
-quad{T<:AbstractFloat}(a::PDiagMat{T}, x::Vector{T}) = wsumsq(a.diag, x)
-invquad{T<:AbstractFloat}(a::PDiagMat{T}, x::Vector{T}) = wsumsq(a.inv_diag, x)
+quad(a::PDiagMat, x::Vector) = wsumsq(a.diag, x)
+invquad(a::PDiagMat, x::Vector) = wsumsq(a.inv_diag, x)
 
-quad!{T<:AbstractFloat}(r::AbstractArray{T}, a::PDiagMat{T}, x::Matrix{T}) = At_mul_B!(r, abs2(x), a.diag)
-invquad!{T<:AbstractFloat}(r::AbstractArray{T}, a::PDiagMat{T}, x::Matrix{T}) = At_mul_B!(r, abs2(x), a.inv_diag)
+quad!(r::AbstractArray, a::PDiagMat, x::Matrix) = At_mul_B!(r, abs2(x), a.diag)
+invquad!(r::AbstractArray, a::PDiagMat, x::Matrix) = At_mul_B!(r, abs2(x), a.inv_diag)
 
 
 ### tri products
 
-function X_A_Xt{T<:AbstractFloat}(a::PDiagMat{T}, x::StridedMatrix{T})
+function X_A_Xt(a::PDiagMat, x::StridedMatrix)
     z = x .* reshape(sqrt(a.diag), 1, dim(a))
     A_mul_Bt(z, z)
 end
 
-function Xt_A_X{T<:AbstractFloat}(a::PDiagMat{T}, x::StridedMatrix{T})
+function Xt_A_X(a::PDiagMat, x::StridedMatrix)
     z = x .* sqrt(a.diag)
     At_mul_B(z, z)
 end
 
-function X_invA_Xt{T<:AbstractFloat}(a::PDiagMat{T}, x::StridedMatrix{T})
+function X_invA_Xt(a::PDiagMat, x::StridedMatrix)
     z = x .* reshape(sqrt(a.inv_diag), 1, dim(a))
     A_mul_Bt(z, z)
 end
 
-function Xt_invA_X{T<:AbstractFloat}(a::PDiagMat{T}, x::StridedMatrix{T})
+function Xt_invA_X(a::PDiagMat, x::StridedMatrix)
     z = x .* sqrt(a.inv_diag)
     At_mul_B(z, z)
 end

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -1,5 +1,5 @@
 # Full positive definite matrix together with a Cholesky factorization object
-immutable PDMat{T<:AbstractFloat,S<:AbstractMatrix} <: AbstractPDMat{T}
+immutable PDMat{T<:Real,S<:AbstractMatrix} <: AbstractPDMat{T}
     dim::Int
     mat::S
     chol::CholType{T,S}
@@ -26,14 +26,14 @@ diag(a::PDMat) = diag(a.mat)
 
 ### Arithmetics
 
-function pdadd!{T<:AbstractFloat}(r::Matrix{T}, a::Matrix{T}, b::PDMat{T}, c::T)
+function pdadd!(r::Matrix, a::Matrix, b::PDMat, c)
     @check_argdims size(r) == size(a) == size(b)
     _addscal!(r, a, b.mat, c)
 end
 
-*{T<:AbstractFloat}(a::PDMat{T}, c::T) = PDMat(a.mat * c)
-*{T<:AbstractFloat}(a::PDMat{T}, x::StridedVecOrMat{T}) = a.mat * x
-\{T<:AbstractFloat}(a::PDMat{T}, x::StridedVecOrMat{T}) = a.chol \ x
+*{T<:Real}(a::PDMat{T}, c::T) = PDMat(a.mat * c)
+*(a::PDMat, x::StridedVecOrMat) = a.mat * x
+\(a::PDMat, x::StridedVecOrMat) = a.chol \ x
 
 
 ### Algebra
@@ -46,13 +46,13 @@ eigmin(a::PDMat) = eigmin(a.mat)
 
 ### whiten and unwhiten
 
-function whiten!{T<:AbstractFloat}(r::StridedVecOrMat{T}, a::PDMat{T}, x::StridedVecOrMat{T})
+function whiten!(r::StridedVecOrMat, a::PDMat, x::StridedVecOrMat)
     cf = a.chol[:UL]
     istriu(cf) ? Ac_ldiv_B!(cf, _rcopy!(r, x)) : A_ldiv_B!(cf, _rcopy!(r, x))
     return r
 end
 
-function unwhiten!{T<:AbstractFloat}(r::StridedVecOrMat{T}, a::PDMat{T}, x::StridedVecOrMat{T})
+function unwhiten!(r::StridedVecOrMat, a::PDMat, x::StridedVecOrMat)
     cf = a.chol[:UL]
     istriu(cf) ? Ac_mul_B!(cf, _rcopy!(r, x)) : A_mul_B!(cf, _rcopy!(r, x))
     return r
@@ -61,37 +61,37 @@ end
 
 ### quadratic forms
 
-quad{T<:AbstractFloat}(a::PDMat{T}, x::StridedVector{T}) = dot(x, a * x)
-invquad{T<:AbstractFloat}(a::PDMat{T}, x::StridedVector{T}) = dot(x, a \ x)
+quad(a::PDMat, x::StridedVector) = dot(x, a * x)
+invquad(a::PDMat, x::StridedVector) = dot(x, a \ x)
 
-quad!{T<:AbstractFloat}(r::AbstractArray{T}, a::PDMat{T}, x::StridedMatrix{T}) = colwise_dot!(r, x, a.mat * x)
-invquad!{T<:AbstractFloat}(r::AbstractArray{T}, a::PDMat{T}, x::StridedMatrix{T}) = colwise_dot!(r, x, a.mat \ x)
+quad!(r::AbstractArray, a::PDMat, x::StridedMatrix) = colwise_dot!(r, x, a.mat * x)
+invquad!(r::AbstractArray, a::PDMat, x::StridedMatrix) = colwise_dot!(r, x, a.mat \ x)
 
 
 ### tri products
 
-function X_A_Xt{T<:AbstractFloat}(a::PDMat{T}, x::StridedMatrix{T})
+function X_A_Xt(a::PDMat, x::StridedMatrix)
     z = copy(x)
     cf = a.chol[:UL]
     istriu(cf) ? A_mul_Bc!(z, cf) : A_mul_B!(z, cf)
     A_mul_Bt(z, z)
 end
 
-function Xt_A_X{T<:AbstractFloat}(a::PDMat{T}, x::StridedMatrix{T})
+function Xt_A_X(a::PDMat, x::StridedMatrix)
     z = copy(x)
     cf = a.chol[:UL]
     istriu(cf) ? A_mul_B!(cf, z) : Ac_mul_B!(cf, z)
     At_mul_B(z, z)
 end
 
-function X_invA_Xt{T<:AbstractFloat}(a::PDMat{T}, x::StridedMatrix{T})
+function X_invA_Xt(a::PDMat, x::StridedMatrix)
     z = copy(x)
     cf = a.chol[:UL]
     istriu(cf) ? A_rdiv_B!(z, cf) : A_rdiv_Bc!(z, cf)
     A_mul_Bt(z, z)
 end
 
-function Xt_invA_X{T<:AbstractFloat}(a::PDMat{T}, x::StridedMatrix{T})
+function Xt_invA_X(a::PDMat, x::StridedMatrix)
     z = copy(x)
     cf = a.chol[:UL]
     istriu(cf) ? Ac_ldiv_B!(cf, z) : A_ldiv_B!(cf, z)

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -1,5 +1,5 @@
 # Sparse positive definite matrix together with a Cholesky factorization object
-immutable PDSparseMat{T<:AbstractFloat,S<:AbstractSparseMatrix} <: AbstractPDMat{T}
+immutable PDSparseMat{T<:Real,S<:AbstractSparseMatrix} <: AbstractPDMat{T}
   dim::Int
   mat::S
   chol::CholTypeSparse
@@ -26,32 +26,32 @@ diag(a::PDSparseMat) = diag(a.mat)
 ### Arithmetics
 
 # add `a * c` to a dense matrix `m` of the same size inplace.
-function pdadd!{T<:AbstractFloat}(r::Matrix{T}, a::Matrix{T}, b::PDSparseMat{T}, c::T)
+function pdadd!(r::Matrix, a::Matrix, b::PDSparseMat, c)
     @check_argdims size(r) == size(a) == size(b)
     _addscal!(r, a, b.mat, c)
 end
 
-*{T<:AbstractFloat}(a::PDSparseMat{T}, c::T) = PDSparseMat(a.mat * c)
-*{T<:AbstractFloat}(a::PDSparseMat{T}, x::StridedVecOrMat{T}) = a.mat * x
-\{T<:AbstractFloat}(a::PDSparseMat{T}, x::StridedVecOrMat{T}) = convert(Array{T},a.chol \ convert(Array{Float64},x)) #to avoid limitations in sparse factorization library CHOLMOD, see e.g., julia issue #14076
+*{T<:Real}(a::PDSparseMat, c::T) = PDSparseMat(a.mat * c)
+*(a::PDSparseMat, x::StridedVecOrMat) = a.mat * x
+\{T<:Real}(a::PDSparseMat{T}, x::StridedVecOrMat{T}) = convert(Array{T},a.chol \ convert(Array{Float64},x)) #to avoid limitations in sparse factorization library CHOLMOD, see e.g., julia issue #14076
 
 
 ### Algebra
 
-inv{T<:AbstractFloat}(a::PDSparseMat{T}) = PDMat( a\eye(T,a.dim) )
+inv{T<:Real}(a::PDSparseMat{T}) = PDMat( a\eye(T,a.dim) )
 logdet(a::PDSparseMat) = logdet(a.chol)
-eigmax{T<:AbstractFloat}(a::PDSparseMat{T}) = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:LM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
-eigmin{T<:AbstractFloat}(a::PDSparseMat{T}) = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:SM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
+eigmax{T<:Real}(a::PDSparseMat{T}) = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:LM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
+eigmin{T<:Real}(a::PDSparseMat{T}) = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:SM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
 
 
 ### whiten and unwhiten
 
-function whiten!{T<:AbstractFloat}(r::StridedVecOrMat{T}, a::PDSparseMat{T}, x::StridedVecOrMat{T})
+function whiten!(r::StridedVecOrMat, a::PDSparseMat, x::StridedVecOrMat)
     r[:] = sparse(chol_lower(a.chol)) \ x
     return r
 end
 
-function unwhiten!{T<:AbstractFloat}(r::StridedVecOrMat{T}, a::PDSparseMat{T}, x::StridedVecOrMat{T})
+function unwhiten!(r::StridedVecOrMat, a::PDSparseMat, x::StridedVecOrMat)
     r[:] = sparse(chol_lower(a.chol)) * x
     return r
 end
@@ -59,17 +59,17 @@ end
 
 ### quadratic forms
 
-quad{T<:AbstractFloat}(a::PDSparseMat{T}, x::StridedVector{T}) = dot(x, a * x)
-invquad{T<:AbstractFloat}(a::PDSparseMat{T}, x::StridedVector{T}) = dot(x, a \ x)
+quad(a::PDSparseMat, x::StridedVector) = dot(x, a * x)
+invquad(a::PDSparseMat, x::StridedVector) = dot(x, a \ x)
 
-function quad!{T<:AbstractFloat}(r::AbstractArray{T}, a::PDSparseMat{T}, x::StridedMatrix{T})
+function quad!(r::AbstractArray, a::PDSparseMat, x::StridedMatrix)
     for i in 1:size(x, 2)
         r[i] = quad(a, x[:,i])
     end
     return r
 end
 
-function invquad!{T<:AbstractFloat}(r::AbstractArray{T}, a::PDSparseMat{T}, x::StridedMatrix{T})
+function invquad!(r::AbstractArray, a::PDSparseMat, x::StridedMatrix)
     for i in 1:size(x, 2)
         r[i] = invquad(a, x[:,i])
     end
@@ -79,24 +79,24 @@ end
 
 ### tri products
 
-function X_A_Xt{T<:AbstractFloat}(a::PDSparseMat{T}, x::StridedMatrix{T})
+function X_A_Xt(a::PDSparseMat, x::StridedMatrix)
     z = x*sparse(chol_lower(a.chol))
     A_mul_Bt(z, z)
 end
 
 
-function Xt_A_X{T<:AbstractFloat}(a::PDSparseMat{T}, x::StridedMatrix{T})
+function Xt_A_X(a::PDSparseMat, x::StridedMatrix)
     z = At_mul_B(x, sparse(chol_lower(a.chol)))
     A_mul_Bt(z, z)
 end
 
 
-function X_invA_Xt{T<:AbstractFloat}(a::PDSparseMat{T}, x::StridedMatrix{T})
+function X_invA_Xt(a::PDSparseMat, x::StridedMatrix)
     z = a \ x'
     x * z
 end
 
-function Xt_invA_X{T<:AbstractFloat}(a::PDSparseMat{T}, x::StridedMatrix{T})
+function Xt_invA_X(a::PDSparseMat, x::StridedMatrix)
     z = a \ x
     At_mul_B(x, z)
 end


### PR DESCRIPTION
Relaxing the parameter type to `T <: Real` would allow PDMats (and thus eventually distributions using PDMats) to make use of automatic differentiation (à la ForwardDiff.jl).