### PR TITLE
added conversions between element types

### DIFF
--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -5,7 +5,7 @@ module PDMats
     using Compat
 
     import Base: +, *, \, /, ==
-    import Base: full, logdet, inv, diag, diagm, scale, scale!, eigmax, eigmin
+    import Base: full, logdet, inv, diag, diagm, scale, scale!, eigmax, eigmin, convert
 
     export
         # Types

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -14,6 +14,8 @@ end
 
 PDiagMat(v::Vector) = PDiagMat(v, ones(v)./v)
 
+### Conversion
+convert{T<:Real}(::Type{PDiagMat{T}}, a::PDiagMat) = PDiagMat(convert(Vector{T}, a.diag))
 
 ### Basics
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -17,6 +17,9 @@ PDMat(mat::Matrix) = PDMat(mat,cholfact(mat))
 PDMat(mat::Symmetric) = PDMat(full(mat))
 PDMat(fac::CholType) = PDMat(full(fac),fac)
 
+### Conversion
+convert{T<:Real}(::Type{PDMat{T}}, a::PDMat) = PDMat(convert(Matrix{T}, a.mat))
+
 ### Basics
 
 dim(a::PDMat) = a.dim

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -16,6 +16,9 @@ end
 PDSparseMat(mat::SparseMatrixCSC) = PDSparseMat(mat, cholfact(mat))
 PDSparseMat(fac::CholTypeSparse) = PDSparseMat(sparse(fac) |> x -> x*x', fac)
 
+### Conversion
+convert{T<:Real}(::Type{PDSparseMat{T}}, a::PDSparseMat) = PDSparseMat(convert(SparseMatrixCSC{T}, a.mat))
+
 ### Basics
 
 dim(a::PDSparseMat) = a.dim

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -9,7 +9,8 @@ end
 ScalMat(d::Int,v::Real) = ScalMat{typeof(one(v)/v)}(d, v, one(v) / v)
 
 ### Conversion
-convert{T<:Real}(::Type{ScalMat{T}}, a::ScalMat) = ScalMat(a.dim, T(a.value))
+# can rewrite convert(T, a.value) as T(a.value) when we drop v0.3 support
+convert{T<:Real}(::Type{ScalMat{T}}, a::ScalMat) = ScalMat(a.dim, convert(T, a.value))
 
 ### Basics
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -6,7 +6,10 @@ immutable ScalMat{T<:Real} <: AbstractPDMat{T}
   inv_value::T
 end
 
-ScalMat(d::Int,v::Real) = ScalMat{typeof(v)}(d, v, one(v) / v)
+ScalMat(d::Int,v::Real) = ScalMat{typeof(one(v)/v)}(d, v, one(v) / v)
+
+### Conversion
+convert{T<:Real}(::Type{ScalMat{T}}, a::ScalMat) = ScalMat(a.dim, T(a.value))
 
 ### Basics
 

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -30,7 +30,7 @@ m = eye(Float32,2)
 m = ones(Float32,2)
 @test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
 x = one(Float32); d = 4
-@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x).value
+@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
 if VERSION >= v"0.4.2"
     s = speye(Float32, 2, 2)
     @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -12,6 +12,7 @@ for T in [Float64,Float32]
   #for Julia v0.3, do not test sparse matrices with Float32 (see issue #14076)
   (T == Float64 || VERSION >= v"0.4.2") && (s = speye(T,2,2) ; @test PDSparseMat(s,cholfact(s)).mat == PDSparseMat(s).mat == PDSparseMat(cholfact(s)).mat)
 
+
   #test the functionality
   M = convert(Array{T,2},[4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
   V = convert(Array{T,1},[1.5, 2.5, 2.0])
@@ -22,4 +23,15 @@ for T in [Float64,Float32]
   call_test_pdmat(ScalMat(3,x),x*eye(T,3)) #tests of ScalMat
   #for Julia v0.3, do not test sparse matrices with Float32 (see issue #14076)
   (T == Float64 || VERSION >= v"0.4.2") && call_test_pdmat(PDSparseMat(sparse(M)),M)
+end
+
+m = eye(Float32,2)
+@test convert(PDMat{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
+m = ones(Float32,2)
+@test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
+x = one(Float32); d = 4
+@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, Float64(x)).value
+if VERSION >= v"0.4.2"
+    s = speye(Float32, 2, 2)
+    @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat
 end

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -30,7 +30,7 @@ m = eye(Float32,2)
 m = ones(Float32,2)
 @test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
 x = one(Float32); d = 4
-@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
+@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, @compat Float64(x)).value
 if VERSION >= v"0.4.2"
     s = speye(Float32, 2, 2)
     @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -30,7 +30,7 @@ m = eye(Float32,2)
 m = ones(Float32,2)
 @test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
 x = one(Float32); d = 4
-@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, @compat Float64(x)).value
+@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x).value
 if VERSION >= v"0.4.2"
     s = speye(Float32, 2, 2)
     @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -30,7 +30,7 @@ m = eye(Float32,2)
 m = ones(Float32,2)
 @test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
 x = one(Float32); d = 4
-@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, Float64(x)).value
+@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
 if VERSION >= v"0.4.2"
     s = speye(Float32, 2, 2)
     @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat


### PR DESCRIPTION
Now that element types of PDMats can vary, and we might want to promote element types for multiple parameters in Distributions, it would be handy to have PDMats take care of conversion between matrices with different element types.