### PR TITLE
Define AbstractArray{T} convert methods.

### DIFF
--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -15,7 +15,8 @@ end
 PDiagMat(v::Vector) = PDiagMat(v, ones(v)./v)
 
 ### Conversion
-convert{T<:Real}(::Type{PDiagMat{T}}, a::PDiagMat) = PDiagMat(convert(Vector{T}, a.diag))
+convert{T<:Real}(::Type{PDiagMat{T}},      a::PDiagMat) = PDiagMat(convert(AbstractArray{T}, a.diag))
+convert{T<:Real}(::Type{AbstractArray{T}}, a::PDiagMat) = convert(PDiagMat{T}, a)
 
 ### Basics
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -18,7 +18,8 @@ PDMat(mat::Symmetric) = PDMat(full(mat))
 PDMat(fac::CholType) = PDMat(full(fac),fac)
 
 ### Conversion
-convert{T<:Real}(::Type{PDMat{T}}, a::PDMat) = PDMat(convert(Matrix{T}, a.mat))
+convert{T<:Real}(::Type{PDMat{T}},         a::PDMat) = PDMat(convert(AbstractArray{T}, a.mat))
+convert{T<:Real}(::Type{AbstractArray{T}}, a::PDMat) = convert(PDMat{T}, a)
 
 ### Basics
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -9,8 +9,8 @@ end
 ScalMat(d::Int,v::Real) = ScalMat{typeof(one(v)/v)}(d, v, one(v) / v)
 
 ### Conversion
-# can rewrite convert(T, a.value) as T(a.value) when we drop v0.3 support
-convert{T<:Real}(::Type{ScalMat{T}}, a::ScalMat) = ScalMat(a.dim, convert(T, a.value))
+convert{T<:Real}(::Type{ScalMat{T}}, a::ScalMat) = ScalMat(a.dim, T(a.value), T(a.inv_value))
+convert{T<:Real}(::Type{AbstractArray{T}}, a::ScalMat) = convert(ScalMat{T}, a)
 
 ### Basics
 

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -32,10 +32,13 @@ end
 
 m = eye(Float32,2)
 @test convert(PDMat{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
+@test convert(AbstractArray{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
 m = ones(Float32,2)
 @test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
+@test convert(AbstractArray{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
 x = one(Float32); d = 4
 @test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
+@test convert(AbstractArray{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
 if VERSION >= v"0.4.2"
     s = speye(Float32, 2, 2)
     @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat


### PR DESCRIPTION
These will be useful for getting `Distributions` running on 0.6 and they match what we define for arrays in Base.