### PR TITLE
Only define methods for sparse matrices when CHOLMOD is available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false
-# script:
-#   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("PDMats"); Pkg.test("PDMats"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("PDMats")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Uniform interface for positive definite matrices of various structures.
 
 [![Build Status](https://travis-ci.org/JuliaStats/PDMats.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/PDMats.jl)
 [![Coverage Status](https://img.shields.io/coveralls/JuliaStats/PDMats.jl.svg)](https://coveralls.io/r/JuliaStats/PDMats.jl?branch=master)
-[![PDMats](http://pkg.julialang.org/badges/PDMats_0.3.svg)](http://pkg.julialang.org/?pkg=PDMats&ver=0.3)
-[![PDMats](http://pkg.julialang.org/badges/PDMats_0.4.svg)](http://pkg.julialang.org/?pkg=PDMats&ver=0.4)
+[![PDMats](http://pkg.julialang.org/badges/PDMats_0.3.svg)](http://pkg.julialang.org/?pkg=PDMats&ver=0.5)
+[![PDMats](http://pkg.julialang.org/badges/PDMats_0.4.svg)](http://pkg.julialang.org/?pkg=PDMats&ver=0.6)
 
 --------------
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.5
 Compat 0.18.0

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -51,7 +51,9 @@ module PDMats
     include("utils.jl")
 
     include("pdmat.jl")
-    include("pdsparsemat.jl")
+    if isdefined(Base.SparseArrays, :CHOLMOD)
+        include("pdsparsemat.jl")
+    end
     include("pdiagmat.jl")
     include("scalmat.jl")
 

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -4,27 +4,37 @@
 +(a::PDMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
 +(a::PDiagMat, b::AbstractPDMat) = PDMat(_adddiag!(full(b), a.diag))
 +(a::ScalMat, b::AbstractPDMat) = PDMat(_adddiag!(full(b), a.value))
-+(a::PDSparseMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    +(a::PDSparseMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
+end
 
 +(a::PDMat, b::PDMat) = PDMat(a.mat + b.mat)
 +(a::PDMat, b::PDiagMat) = PDMat(_adddiag(a.mat, b.diag))
 +(a::PDMat, b::ScalMat) = PDMat(_adddiag(a.mat, b.value))
-+(a::PDMat, b::PDSparseMat) = PDMat(a.mat + b.mat)
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    +(a::PDMat, b::PDSparseMat) = PDMat(a.mat + b.mat)
+end
 
 +(a::PDiagMat, b::PDMat) = PDMat(_adddiag(b.mat, a.diag))
 +(a::PDiagMat, b::PDiagMat) = PDiagMat(a.diag + b.diag)
 +(a::PDiagMat, b::ScalMat) = PDiagMat(a.diag .+ b.value)
-+(a::PDiagMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.diag))
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    +(a::PDiagMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.diag))
+end
 
 +(a::ScalMat, b::PDMat) = PDMat(_adddiag(b.mat, a.value))
 +(a::ScalMat, b::PDiagMat) = PDiagMat(a.value .+ b.diag)
 +(a::ScalMat, b::ScalMat) = ScalMat(a.dim, a.value + b.value)
-+(a::ScalMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.value))
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    +(a::ScalMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.value))
+end
 
-+(a::PDSparseMat, b::PDMat) = PDMat(full(a) + b.mat)
-+(a::PDSparseMat, b::PDiagMat) = PDSparseMat(_adddiag(a.mat, b.diag))
-+(a::PDSparseMat, b::ScalMat) = PDSparseMat(_adddiag(a.mat, b.value))
-+(a::PDSparseMat, b::PDSparseMat) = PDSparseMat(a.mat + b.mat)
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    +(a::PDSparseMat, b::PDMat) = PDMat(full(a) + b.mat)
+    +(a::PDSparseMat, b::PDiagMat) = PDSparseMat(_adddiag(a.mat, b.diag))
+    +(a::PDSparseMat, b::ScalMat) = PDSparseMat(_adddiag(a.mat, b.value))
+    +(a::PDSparseMat, b::PDSparseMat) = PDSparseMat(a.mat + b.mat)
+end
 
 
 # between pdmat and uniformscaling (multiple of identity)
@@ -35,24 +45,34 @@
 pdadd(a::PDMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + full(b * c))
 pdadd(a::PDiagMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(full(b * c), a.diag, one(c)))
 pdadd(a::ScalMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(full(b * c), a.value))
-pdadd(a::PDSparseMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + full(b * c))
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    pdadd(a::PDSparseMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + full(b * c))
+end
 
 pdadd(a::PDMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
 pdadd(a::PDMat, b::PDiagMat, c::Real) = PDMat(_adddiag(a.mat, b.diag, c))
 pdadd(a::PDMat, b::ScalMat, c::Real) = PDMat(_adddiag(a.mat, b.value * c))
-pdadd(a::PDMat, b::PDSparseMat, c::Real) = PDMat(a.mat + b.mat * c)
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    pdadd(a::PDMat, b::PDSparseMat, c::Real) = PDMat(a.mat + b.mat * c)
+end
 
 pdadd(a::PDiagMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.diag, one(c)))
 pdadd(a::PDiagMat, b::PDiagMat, c::Real) = PDiagMat(a.diag + b.diag * c)
 pdadd(a::PDiagMat, b::ScalMat, c::Real) = PDiagMat(a.diag .+ b.value * c)
-pdadd(a::PDiagMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.diag, one(c)))
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    pdadd(a::PDiagMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.diag, one(c)))
+end
 
 pdadd(a::ScalMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.value))
 pdadd(a::ScalMat, b::PDiagMat, c::Real) = PDiagMat(a.value .+ b.diag * c)
 pdadd(a::ScalMat, b::ScalMat, c::Real) = ScalMat(a.dim, a.value + b.value * c)
-pdadd(a::ScalMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.value))
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    pdadd(a::ScalMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.value))
+end
 
-pdadd(a::PDSparseMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
-pdadd(a::PDSparseMat, b::PDiagMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.diag, c))
-pdadd(a::PDSparseMat, b::ScalMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.value * c))
-pdadd(a::PDSparseMat, b::PDSparseMat, c::Real) = PDSparseMat(a.mat + b.mat * c)
+if isdefined(Base.SparseArrays, :CHOLMOD)
+    pdadd(a::PDSparseMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
+    pdadd(a::PDSparseMat, b::PDiagMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.diag, c))
+    pdadd(a::PDSparseMat, b::ScalMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.value * c))
+    pdadd(a::PDSparseMat, b::PDSparseMat, c::Real) = PDSparseMat(a.mat + b.mat * c)
+end

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -1,26 +1,8 @@
-# needs special attention to Cholesky, as the syntax & behavior changes in 0.4-pre
+@compat CholType{T,S<:AbstractMatrix} = Cholesky{T,S}
+chol_lower(a::Matrix) = ctranspose(chol(a))
 
-if VERSION >= v"0.5.0-dev+907"
-    @compat CholType{T,S<:AbstractMatrix} = Cholesky{T,S}
-    chol_lower(a::Matrix) = ctranspose(chol(a))
-
+if isdefined(Base.SparseArrays, :CHOLMOD)
     @compat CholTypeSparse{T} = SparseArrays.CHOLMOD.Factor{T}
 
     chol_lower(cf::CholTypeSparse) = cf[:L]
-elseif VERSION >= v"0.4.0-dev+4370"
-    # error("Choleksy changes in 0.4.0-dev+4370 (PR #10862), we are still working to make it work with these changes.")
-
-    @compat CholType{T,S<:AbstractMatrix} = Cholesky{T,S}
-    chol_lower(a::Matrix) = chol(a, Val{:L})
-
-    @compat CholTypeSparse{T} = SparseArrays.CHOLMOD.Factor{T}
-
-    chol_lower(cf::CholTypeSparse) = cf[:L]
-else
-    @compat CholType{T,S} = Cholesky{T}
-    chol_lower(a::Matrix) = chol(a, :L)
-
-    @compat CholTypeSparse{T} = Base.LinAlg.CHOLMOD.CholmodFactor{T}
-
-    chol_lower(cf::CholTypeSparse) = cf
 end


### PR DESCRIPTION
Fixes #43. This will most likely also drop support for 0.4.