### PR TITLE
Use Compat.Test instead of Base.Test for Julia v0.7 compatibility

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat 0.18.0
+Compat 0.33

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -4,7 +4,7 @@
 #       the implementation of a subtype of AbstractPDMat
 #
 
-import Base.Test: @test
+import Compat.Test: @test
 using Compat: view
 
 ## driver function

--- a/test/addition.jl
+++ b/test/addition.jl
@@ -1,7 +1,7 @@
 # addition of positive definite matrices
 
 using PDMats
-using Base.Test
+using Compat.Test
 
 for T in [Float64,Float32]
 

--- a/test/generics.jl
+++ b/test/generics.jl
@@ -1,7 +1,7 @@
 
 # test operators with pd matrix types
 using PDMats
-using Base.Test
+using Compat.Test
 
 # test scalar multiplication 
 print_with_color(:blue, "Testing scalar multiplication\n")

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -1,6 +1,6 @@
 # test pd matrix types
 using PDMats
-using Base.Test
+using Compat.Test
 
 call_test_pdmat(p::AbstractPDMat,m::Matrix) = test_pdmat(p,m,cmat_eq=true,verbose=1)
 


### PR DESCRIPTION
Similar to #66, but compatible to pre-v0.7