### PR TITLE
WIP: Updates for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
-  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat 0.33
+julia 0.7.0-DEV.3449

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -2,10 +2,14 @@ __precompile__()
 
 module PDMats
 
-    using Compat
+    using LinearAlgebra
+    using SparseArrays
+    using SuiteSparse
 
-    import Base: +, *, \, /, ==
-    import Base: full, logdet, inv, diag, diagm, eigmax, eigmin, convert
+    import Base: +, *, \, /, ==, convert
+    import LinearAlgebra: logdet, inv, diag, diagm, eigmax, eigmin, Cholesky
+    import LinearAlgebra.BLAS: nrm2, axpy!, gemv!, gemm, gemm!, trmv, trmv!, trmm, trmm!
+    import LinearAlgebra.LAPACK: trtrs!
 
     export
         # Types
@@ -17,7 +21,6 @@ module PDMats
 
         # Functions
         dim,
-        full,
         whiten,
         whiten!,
         unwhiten,
@@ -36,14 +39,11 @@ module PDMats
         Xt_invA_X,
         test_pdmat
 
-    import Base.BLAS: nrm2, axpy!, gemv!, gemm, gemm!, trmv, trmv!, trmm, trmm!
-    import Base.LAPACK: trtrs!
-    import Base.LinAlg: A_ldiv_B!, A_mul_B!, A_mul_Bc!, A_rdiv_B!, A_rdiv_Bc!, Ac_ldiv_B!, Cholesky
-
-
     # The abstract base type
 
     abstract type AbstractPDMat{T<:Real} end
+
+    const HAVE_CHOLMOD = isdefined(SuiteSparse, :CHOLMOD)
 
     # source files
 
@@ -51,7 +51,7 @@ module PDMats
     include("utils.jl")
 
     include("pdmat.jl")
-    if isdefined(Base.SparseArrays, :CHOLMOD)
+    if HAVE_CHOLMOD
         include("pdsparsemat.jl")
     end
     include("pdiagmat.jl")
@@ -59,8 +59,6 @@ module PDMats
 
     include("generics.jl")
     include("addition.jl")
-
-    include("testutils.jl")
 
     include("deprecates.jl")
 

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -1,36 +1,36 @@
 
 # between pdmat and pdmat
 
-+(a::PDMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
-+(a::PDiagMat, b::AbstractPDMat) = PDMat(_adddiag!(full(b), a.diag))
-+(a::ScalMat, b::AbstractPDMat) = PDMat(_adddiag!(full(b), a.value))
-if isdefined(Base.SparseArrays, :CHOLMOD)
-    +(a::PDSparseMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
++(a::PDMat, b::AbstractPDMat) = PDMat(a.mat + Matrix(b))
++(a::PDiagMat, b::AbstractPDMat) = PDMat(_adddiag!(Matrix(b), a.diag))
++(a::ScalMat, b::AbstractPDMat) = PDMat(_adddiag!(Matrix(b), a.value))
+if HAVE_CHOLMOD
+    +(a::PDSparseMat, b::AbstractPDMat) = PDMat(a.mat + Matrix(b))
 end
 
 +(a::PDMat, b::PDMat) = PDMat(a.mat + b.mat)
 +(a::PDMat, b::PDiagMat) = PDMat(_adddiag(a.mat, b.diag))
 +(a::PDMat, b::ScalMat) = PDMat(_adddiag(a.mat, b.value))
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     +(a::PDMat, b::PDSparseMat) = PDMat(a.mat + b.mat)
 end
 
 +(a::PDiagMat, b::PDMat) = PDMat(_adddiag(b.mat, a.diag))
 +(a::PDiagMat, b::PDiagMat) = PDiagMat(a.diag + b.diag)
 +(a::PDiagMat, b::ScalMat) = PDiagMat(a.diag .+ b.value)
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     +(a::PDiagMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.diag))
 end
 
 +(a::ScalMat, b::PDMat) = PDMat(_adddiag(b.mat, a.value))
 +(a::ScalMat, b::PDiagMat) = PDiagMat(a.value .+ b.diag)
 +(a::ScalMat, b::ScalMat) = ScalMat(a.dim, a.value + b.value)
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     +(a::ScalMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.value))
 end
 
-if isdefined(Base.SparseArrays, :CHOLMOD)
-    +(a::PDSparseMat, b::PDMat) = PDMat(full(a) + b.mat)
+if HAVE_CHOLMOD
+    +(a::PDSparseMat, b::PDMat) = PDMat(Matrix(a) + b.mat)
     +(a::PDSparseMat, b::PDiagMat) = PDSparseMat(_adddiag(a.mat, b.diag))
     +(a::PDSparseMat, b::ScalMat) = PDSparseMat(_adddiag(a.mat, b.value))
     +(a::PDSparseMat, b::PDSparseMat) = PDSparseMat(a.mat + b.mat)
@@ -42,35 +42,35 @@ end
 +(a::AbstractPDMat, b::UniformScaling) = a + ScalMat(dim(a), b.λ)
 +(a::UniformScaling, b::AbstractPDMat) = ScalMat(dim(b), a.λ) + b
 
-pdadd(a::PDMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + full(b * c))
-pdadd(a::PDiagMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(full(b * c), a.diag, one(c)))
-pdadd(a::ScalMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(full(b * c), a.value))
-if isdefined(Base.SparseArrays, :CHOLMOD)
-    pdadd(a::PDSparseMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + full(b * c))
+pdadd(a::PDMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + Matrix(b * c))
+pdadd(a::PDiagMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(Matrix(b * c), a.diag, one(c)))
+pdadd(a::ScalMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(Matrix(b * c), a.value))
+if HAVE_CHOLMOD
+    pdadd(a::PDSparseMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + Matrix(b * c))
 end
 
 pdadd(a::PDMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
 pdadd(a::PDMat, b::PDiagMat, c::Real) = PDMat(_adddiag(a.mat, b.diag, c))
 pdadd(a::PDMat, b::ScalMat, c::Real) = PDMat(_adddiag(a.mat, b.value * c))
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::PDMat, b::PDSparseMat, c::Real) = PDMat(a.mat + b.mat * c)
 end
 
 pdadd(a::PDiagMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.diag, one(c)))
 pdadd(a::PDiagMat, b::PDiagMat, c::Real) = PDiagMat(a.diag + b.diag * c)
 pdadd(a::PDiagMat, b::ScalMat, c::Real) = PDiagMat(a.diag .+ b.value * c)
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::PDiagMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.diag, one(c)))
 end
 
 pdadd(a::ScalMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.value))
 pdadd(a::ScalMat, b::PDiagMat, c::Real) = PDiagMat(a.value .+ b.diag * c)
 pdadd(a::ScalMat, b::ScalMat, c::Real) = ScalMat(a.dim, a.value + b.value * c)
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::ScalMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.value))
 end
 
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::PDSparseMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
     pdadd(a::PDSparseMat, b::PDiagMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.diag, c))
     pdadd(a::PDSparseMat, b::ScalMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.value * c))

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -1,8 +1,8 @@
 CholType{T,S<:AbstractMatrix} = Cholesky{T,S}
 chol_lower(a::Matrix) = chol(a)'
 
-if isdefined(Base.SparseArrays, :CHOLMOD)
-    CholTypeSparse{T} = SparseArrays.CHOLMOD.Factor{T}
+if HAVE_CHOLMOD
+    CholTypeSparse{T} = SuiteSparse.CHOLMOD.Factor{T}
 
     chol_lower(cf::CholTypeSparse) = cf[:L]
 end

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,19 +1,8 @@
 # deprecated functions
 
-import Base: depwarn
+using Base: @deprecate
 
-function add!(a::Matrix, b::AbstractPDMat)
-    depwarn("add! is deprecated in favor of pdadd!", :add!)
-    pdadd!(a, b)
-end
-
-function add_scal!(a::Matrix, b::AbstractPDMat, c::Real)
-    depwarn("add! is deprecated in favor of pdadd!", :add_scal!)
-    pdadd!(a, b, c)
-end
-
-function add_scal(a::Matrix, b::AbstractPDMat, c::Real)
-    depwarn("add_scal is deprecated in favor of pdadd", :add_scal)
-    pdadd(a, b, c)
-end
-
+@deprecate add!(a::Matrix, b::AbstractPDMat) pdadd!(a, b)
+@deprecate add_scal!(a::Matrix, b::AbstractPDMat, c::Real) pdadd!(a, b, c)
+@deprecate add_scal(a::Matrix, b::AbstractPDMat, c::Real) pdadd(a, b, c)
+@deprecate full(a::AbstractPDMat) Matrix(a)

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -3,7 +3,7 @@
 ## Basic functions
 
 Base.eltype(a::AbstractPDMat{T}) where {T<:Real} = T
-Base.eltype(::Type{AbstractPDMat{T}}) where {T<:Real} = T
+Base.eltype(::Type{P}) where P<:AbstractPDMat{T} where T<:Real = T
 Base.ndims(a::AbstractPDMat) = 2
 Base.size(a::AbstractPDMat) = (dim(a), dim(a))
 Base.size(a::AbstractPDMat, i::Integer) = 1 <= i <= 2 ? dim(a) : 1
@@ -40,10 +40,10 @@ unwhiten(a::AbstractPDMat, x::StridedVecOrMat) = unwhiten!(similar(x), a, x)
 
 function quad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
-    quad!(Array{promote_type(T, S)}(size(x,2)), a, x)
+    quad!(Array{promote_type(T, S)}(uninitialized, size(x, 2)), a, x)
 end
 
 function invquad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
-    invquad!(Array{promote_type(T, S)}(size(x,2)), a, x)
+    invquad!(Array{promote_type(T, S)}(uninitialized, size(x, 2)), a, x)
 end

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -1,9 +1,9 @@
 # Sparse positive definite matrix together with a Cholesky factorization object
 struct PDSparseMat{T<:Real,S<:AbstractSparseMatrix} <: AbstractPDMat{T}
-  dim::Int
-  mat::S
-  chol::CholTypeSparse
-  PDSparseMat{T,S}(d::Int,m::AbstractSparseMatrix{T},c::CholTypeSparse) where {T,S} = new{T,S}(d,m,c) #add {T} to CholTypeSparse argument once #14076 is implemented
+    dim::Int
+    mat::S
+    chol::CholTypeSparse
+    PDSparseMat{T,S}(d::Int,m::AbstractSparseMatrix{T},c::CholTypeSparse) where {T,S} = new{T,S}(d,m,c) #add {T} to CholTypeSparse argument once #14076 is implemented
 end
 
 function PDSparseMat(mat::AbstractSparseMatrix,chol::CholTypeSparse)
@@ -22,7 +22,7 @@ convert(::Type{PDSparseMat{T}}, a::PDSparseMat) where {T<:Real} = PDSparseMat(co
 ### Basics
 
 dim(a::PDSparseMat) = a.dim
-full(a::PDSparseMat) = full(a.mat)
+Base.Matrix(a::PDSparseMat) = Matrix(a.mat)
 diag(a::PDSparseMat) = diag(a.mat)
 
 
@@ -84,13 +84,13 @@ end
 
 function X_A_Xt(a::PDSparseMat, x::StridedMatrix)
     z = x*sparse(chol_lower(a.chol))
-    A_mul_Bt(z, z)
+    z * transpose(z)
 end
 
 
 function Xt_A_X(a::PDSparseMat, x::StridedMatrix)
-    z = At_mul_B(x, sparse(chol_lower(a.chol)))
-    A_mul_Bt(z, z)
+    z = transpose(x) * sparse(chol_lower(a.chol))
+    z * transpose(z)
 end
 
 
@@ -101,5 +101,5 @@ end
 
 function Xt_invA_X(a::PDSparseMat, x::StridedMatrix)
     z = a \ x
-    At_mul_B(x, z)
+    transpose(x) * z
 end

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -1,9 +1,9 @@
 # Scaling matrix
 
 struct ScalMat{T<:Real} <: AbstractPDMat{T}
-  dim::Int
-  value::T
-  inv_value::T
+    dim::Int
+    value::T
+    inv_value::T
 end
 
 ScalMat(d::Int,v::Real) = ScalMat{typeof(one(v)/v)}(d, v, one(v) / v)
@@ -15,7 +15,7 @@ convert(::Type{AbstractArray{T}}, a::ScalMat) where {T<:Real} = convert(ScalMat{
 ### Basics
 
 dim(a::ScalMat) = a.dim
-full(a::ScalMat) = diagm(fill(a.value, a.dim))
+Base.Matrix(a::ScalMat) = diagm(0=>fill(a.value, a.dim))
 diag(a::ScalMat) = fill(a.value, a.dim)
 
 

--- a/test/addition.jl
+++ b/test/addition.jl
@@ -1,36 +1,37 @@
 # addition of positive definite matrices
 
 using PDMats
-using Compat.Test
+using Test
+using LinearAlgebra
 
 for T in [Float64,Float32]
+    @testset "Addition with eltype $T" begin
+        M = convert(Array{T,2},[4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
+        V = convert(Array{T,1},[1.5, 2.5, 2.0])
+        X = convert(T,2.0)
 
-  print_with_color(:blue, "Testing addition with eltype = $T\n")
-  M = convert(Array{T,2},[4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
-  V = convert(Array{T,1},[1.5, 2.5, 2.0])
-  X = convert(T,2.0)
+        pm1 = PDMat(M)
+        pm2 = PDiagMat(V)
+        pm3 = ScalMat(3,X)
+        pm4 = X*I
+        pm5 = PDSparseMat(sparse(M))
 
-  pm1 = PDMat(M)
-  pm2 = PDiagMat(V)
-  pm3 = ScalMat(3,X)
-  pm4 = X*I
-  pm5 = PDSparseMat(sparse(M))
+        pmats = Any[pm1, pm2, pm3, pm5]
 
-  pmats = Any[pm1, pm2, pm3, pm5]
+        for p1 in pmats, p2 in pmats
+            pr = p1 + p2
+            @test size(pr) == size(p1)
+            @test Matrix(pr) ≈ Matrix(p1) + Matrix(p2)
 
-  for p1 in pmats, p2 in pmats
-      pr = p1 + p2
-      @test size(pr) == size(p1)
-      @test full(pr) ≈ full(p1) + full(p2)
+            pr = pdadd(p1, p2, convert(T,1.5))
+            @test size(pr) == size(p1)
+            @test Matrix(pr) ≈ Matrix(p1) + Matrix(p2) * convert(T,1.5)
+        end
 
-      pr = pdadd(p1, p2, convert(T,1.5))
-      @test size(pr) == size(p1)
-      @test full(pr) ≈ full(p1) + full(p2) * convert(T,1.5)
-  end
-
-  for p1 in pmats
-        pr = p1 + pm4
-        @test size(pr) == size(p1)
-        @test full(pr) ≈ full(p1) + pm4
-  end
+        for p1 in pmats
+            pr = p1 + pm4
+            @test size(pr) == size(p1)
+            @test Matrix(pr) ≈ Matrix(p1) + pm4
+        end
+    end
 end

--- a/test/generics.jl
+++ b/test/generics.jl
@@ -1,24 +1,23 @@
-
 # test operators with pd matrix types
 using PDMats
-using Compat.Test
+using Test
 
-# test scalar multiplication 
-print_with_color(:blue, "Testing scalar multiplication\n")
-pm1 = PDMat(eye(3))
-pm2 = PDiagMat(ones(3))
-pm3 = ScalMat(3,1)
+@testset "Scalar multiplication" begin
+    pm1 = PDMat(eye(3))
+    pm2 = PDiagMat(ones(3))
+    pm3 = ScalMat(3,1)
 
-pm1a = PDMat(3.0 .* eye(3))
-pm2a = PDiagMat(3.0 .* ones(3))
-pm3a = ScalMat(3, 3)
+    pm1a = PDMat(3.0 .* eye(3))
+    pm2a = PDiagMat(3.0 .* ones(3))
+    pm3a = ScalMat(3, 3)
 
-pmats = Any[pm1, pm2, pm3]
-pmatsa= Any[pm1a,pm2a,pm3a]
+    pmats = Any[pm1, pm2, pm3]
+    pmatsa= Any[pm1a,pm2a,pm3a]
 
-for i in 1:length(pmats)
-    @test full(3.0 * pmats[i]) == full(pmatsa[i])
-    @test full(pmats[i] * 3.0) == full(pmatsa[i])
-    @test full(3 * pmats[i])   == full(pmatsa[i])
-    @test full(pmats[i] * 3)   == full(pmatsa[i])
+    for i in 1:length(pmats)
+        @test Matrix(3.0 * pmats[i]) == Matrix(pmatsa[i])
+        @test Matrix(pmats[i] * 3.0) == Matrix(pmatsa[i])
+        @test Matrix(3 * pmats[i])   == Matrix(pmatsa[i])
+        @test Matrix(pmats[i] * 3)   == Matrix(pmatsa[i])
+    end
 end

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -1,39 +1,42 @@
 # test pd matrix types
 using PDMats
-using Compat.Test
+using Test
 
 call_test_pdmat(p::AbstractPDMat,m::Matrix) = test_pdmat(p,m,cmat_eq=true,verbose=1)
 
 for T in [Float64, Float32]
-    #test that all external constructors are accessible
-    m = eye(T,2)
-    @test PDMat(m, cholfact(m)).mat == PDMat(Symmetric(m)).mat == PDMat(m).mat == PDMat(cholfact(m)).mat
-    d = ones(T,2)
-    @test PDiagMat(d,d).inv_diag == PDiagMat(d).inv_diag
-    x = one(T)
-    @test ScalMat(2,x,x).inv_value == ScalMat(2,x).inv_value
-    s = speye(T,2,2)
-    @test PDSparseMat(s, cholfact(s)).mat == PDSparseMat(s).mat == PDSparseMat(cholfact(s)).mat
+    @testset "External constructors are accessible (eltype $T)" begin
+        m = Matrix{T}(I, 2, 2)
+        @test PDMat(m, cholfact(m)).mat == PDMat(Symmetric(m)).mat == PDMat(m).mat == PDMat(cholfact(m)).mat
+        d = ones(T,2)
+        @test PDiagMat(d,d).inv_diag == PDiagMat(d).inv_diag
+        x = one(T)
+        @test ScalMat(2,x,x).inv_value == ScalMat(2,x).inv_value
+        s = SparseMatrixCSC{T}(I, 2, 2)
+        @test PDSparseMat(s, cholfact(s)).mat == PDSparseMat(s).mat == PDSparseMat(cholfact(s)).mat
 
-    #test the functionality
-    M = convert(Array{T,2}, [4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
-    V = convert(Array{T,1}, [1.5, 2.5, 2.0])
-    X = convert(T,2.0)
+        #test the functionality
+        M = convert(Array{T,2}, [4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
+        V = convert(Array{T,1}, [1.5, 2.5, 2.0])
+        X = convert(T,2.0)
 
-    call_test_pdmat(PDMat(M), M) #tests of PDMat
-    call_test_pdmat(PDiagMat(V), diagm(V)) #tests of PDiagMat
-    call_test_pdmat(ScalMat(3,x), x*eye(T,3)) #tests of ScalMat
-    call_test_pdmat(PDSparseMat(sparse(M)), M)
+        call_test_pdmat(PDMat(M), M) #tests of PDMat
+        call_test_pdmat(PDiagMat(V), diagm(V)) #tests of PDiagMat
+        call_test_pdmat(ScalMat(3,x), x*eye(T,3)) #tests of ScalMat
+        call_test_pdmat(PDSparseMat(sparse(M)), M)
+    end
 end
 
-m = eye(Float32,2)
-@test convert(PDMat{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
-@test convert(AbstractArray{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
-m = ones(Float32,2)
-@test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
-@test convert(AbstractArray{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
-x = one(Float32); d = 4
-@test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
-@test convert(AbstractArray{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
-s = speye(Float32, 2, 2)
-@test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat
+@testset "Conversion" begin
+    m = Matrix{Float32}(I, 2, 2)
+    @test convert(PDMat{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
+    @test convert(AbstractArray{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
+    m = ones(Float32, 2)
+    @test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
+    @test convert(AbstractArray{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
+    x = one(Float32); d = 4
+    @test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
+    @test convert(AbstractArray{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
+    s = SparseMatrixCSC{Float32}(I, 2, 2)
+    @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,13 @@
-tests = ["pdmtypes", "addition", "generics"]
+using Test
+using PDMats
+using LinearAlgebra
+using SparseArrays
+using SuiteSparse
+
+include("testutils.jl")
+
 println("Running tests ...")
-
-for t in tests
-	println("* $t ")
-	include("$t.jl")
+for t in ["pdmtypes", "addition", "generics"]
+    println("* $t ")
+    include("$t.jl")
 end
-
-

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -4,13 +4,13 @@
 #       the implementation of a subtype of AbstractPDMat
 #
 
-import Compat.Test: @test
-using Compat: view
+using Test
+using PDMats
 
 ## driver function
 function test_pdmat(C::AbstractPDMat, Cmat::Matrix;
                     verbose::Int=2,             # the level to display intermediate steps
-                    cmat_eq::Bool=false,        # require Cmat and full(C) to be exactly equal
+                    cmat_eq::Bool=false,        # require Cmat and Matrix(C) to be exactly equal
                     t_diag::Bool=true,          # whethet to test diag method
                     t_scale::Bool=true,         # whether to test scaling
                     t_add::Bool=true,           # whether to test pdadd
@@ -24,7 +24,7 @@ function test_pdmat(C::AbstractPDMat, Cmat::Matrix;
                     )
 
     d = size(Cmat, 1)
-    verbose >= 1 && print_with_color(:blue, "Testing $(typeof(C)) with dim = $d\n")
+    verbose >= 1 && printstyled("Testing $(typeof(C)) with dim = $d\n", color=:blue)
 
     pdtest_basics(C, Cmat, d, verbose)
     pdtest_cmat(C, Cmat, cmat_eq, verbose)
@@ -53,7 +53,7 @@ end
 
 ## core testing functions
 
-_pdt(vb::Int, s) = (vb >= 2 && print_with_color(:green, "    .. testing $s\n"))
+_pdt(vb::Int, s) = (vb >= 2 && printstyled("    .. testing $s\n", color=:green))
 
 
 function pdtest_basics(C::AbstractPDMat, Cmat::Matrix, d::Int, verbose::Int)
@@ -79,11 +79,11 @@ end
 
 
 function pdtest_cmat(C::AbstractPDMat, Cmat::Matrix, cmat_eq::Bool, verbose::Int)
-    _pdt(verbose, "full")
+    _pdt(verbose, "Matrix")
     if cmat_eq
-        @test full(C) == Cmat
+        @test Matrix(C) == Cmat
     else
-        @test full(C) ≈ Cmat
+        @test Matrix(C) ≈ Cmat
     end
 end
 
@@ -100,8 +100,8 @@ end
 
 function pdtest_scale(C::AbstractPDMat, Cmat::Matrix, verbose::Int)
     _pdt(verbose, "scale")
-    @test full(C * convert(eltype(C),2)) ≈ Cmat * convert(eltype(C),2)
-    @test full(convert(eltype(C),2) * C) ≈ convert(eltype(C),2) * Cmat
+    @test Matrix(C * convert(eltype(C),2)) ≈ Cmat * convert(eltype(C),2)
+    @test Matrix(convert(eltype(C),2) * C) ≈ convert(eltype(C),2) * Cmat
 end
 
 


### PR DESCRIPTION
This PR drops support for Julia versions before the linear algebra functionality was moved to the stdlib and rewrites the `A_mul_B`-style calls to 0.7-style.

Work in progress because I'm not 100% certain I got all of the in-place calls right.

Fixes #71.