### PR TITLE
Changes for Julia v0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Positive definite matrices are widely used in machine learning and probabilistic
 
 ## Positive definite matrix types
 
-This package defines an abstract type ``AbstractPDMat{T<:Real}`` as the base type for positive definite matrices with different internal representations.
+This package defines an abstract type `AbstractPDMat{T<:Real}` as the base type for positive definite matrices with different internal representations.
 
 Elemenent types are in princple all Real types, but in practice this is limited by the support for floating point types in Base.LinAlg.Cholesky.
-  - ``Float64``     Fully supported from Julia 0.3.
-  - ``Float32``     Fully supported from Julia 0.4.2. Full, diagonal and scale matrix types are supported in Julia 0.3 or higher.
-  - ``Float16``     Promoted to ``Float32`` for full, diagonal and scale matrix. Currently unsupported for sparse matrix.
-  - ``BigFloat``    Supported in Julia 0.4 for full, diagonal and scale matrix. Currently unsupported for sparse matrix.
+  - `Float64`     Fully supported from Julia 0.3.
+  - `Float32`     Fully supported from Julia 0.4.2. Full, diagonal and scale matrix types are supported in Julia 0.3 or higher.
+  - `Float16`     Promoted to `Float32` for full, diagonal and scale matrix. Currently unsupported for sparse matrix.
+  - `BigFloat`    Supported in Julia 0.4 for full, diagonal and scale matrix. Currently unsupported for sparse matrix.
 
-* ``PDMat``: full covariance matrix, defined as
+* `PDMat`: full covariance matrix, defined as
 
 ```julia
 struct PDMat{T<:Real,S<:AbstractMatrix} <: AbstractPDMat{T}
@@ -49,7 +49,7 @@ PDMat(chol)         # with the Cholesky factorization
 ```
 
 
-* ``PDiagMat``: diagonal matrix, defined as
+* `PDiagMat`: diagonal matrix, defined as
 
 ```julia
 struct {T<:Real,V<:AbstractVector} <: AbstractPDMat{T}
@@ -66,7 +66,7 @@ PDiagMat(v)         # with the vector of diagonal elements
 ```
 
 
-* ``ScalMat``: uniform scaling matrix, as ``v * eye(d)``, defined as
+* `ScalMat`: uniform scaling matrix, as `v * eye(d)`, defined as
 
 ```julia
 struct ScalMat{T<:Real} <: AbstractPDMat{T}
@@ -83,7 +83,7 @@ ScalMat(d, v)        # with dimension d and diagonal value v
 ```
 
 
-* ``PDSparseMat``: sparse covariance matrix, defined as
+* `PDSparseMat`: sparse covariance matrix, defined as
 
 ```julia
 struct PDSparseMat{T<:Real,S<:AbstractSparseMatrix} <: AbstractPDMat{T}
@@ -108,7 +108,7 @@ PDSparseMat(chol)         # with the Cholesky factorization
 
 ## Common interface
 
-All subtypes of ``AbstractPDMat`` share the same API, *i.e.* with the same set of methods to operate on their instances. These methods are introduced below, where ``a`` is an instance of a subtype of ``AbstractPDMat`` to represent a positive definite matrix, ``x`` be a column vector or a matrix with ``size(x,1) == dim(a)``, and ``c`` be a positive real value.
+All subtypes of `AbstractPDMat` share the same API, *i.e.* with the same set of methods to operate on their instances. These methods are introduced below, where `a` is an instance of a subtype of `AbstractPDMat` to represent a positive definite matrix, `x` be a column vector or a matrix with `size(x,1) == dim(a)`, and `c` be a positive real value.
 
 ```julia
 
@@ -123,7 +123,7 @@ ndims(a)    # the number of dimensions, which is always 2.
 
 eltype(a)   # the element type
 
-full(a)     # return a copy of the matrix in full form.
+Matrix(a)   # return a copy of the matrix in full form.
 
 diag(a)     # return a vector of diagonal elements.
 
@@ -235,11 +235,11 @@ In some situation, it is useful to define a customized subtype of `AbstractPDMat
 
 dim(a::M)       # return the dimension of `a`
 
-full(a::M)      # return a copy of the matrix in full form, of type
-                # ``Matrix{eltype(M)}``.
+Matrix(a::M)    # return a copy of the matrix in full form, of type
+                # `Matrix{eltype(M)}`.
 
 diag(a::M)      # return the vector of diagonal elements, of type
-                # ``Vector{eltype(M)}``.
+                # `Vector{eltype(M)}`.
 
 pdadd!(m, a, c)     # add `a * c` to a dense matrix `m` of the same size
                     # inplace.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7.0-DEV.3449
 Compat 0.33

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -3,7 +3,7 @@ __precompile__()
 module PDMats
 
     using Compat
-    using LinearAlgebra, SparseArrays
+    using IterativeEigensolvers, LinearAlgebra, SparseArrays, SuiteSparse
 
     import Base: +, *, \, /, ==, convert, inv, Matrix
     import LinearAlgebra: logdet, diag, eigmax, eigmin
@@ -37,14 +37,12 @@ module PDMats
         Xt_invA_X,
         test_pdmat
 
-#    import Base.BLAS: nrm2, axpy!, gemv!, gemm, gemm!, trmv, trmv!, trmm, trmm!
-#    import Base.LAPACK: trtrs!
-    import LinearAlgebra: A_ldiv_B!, A_mul_B!, A_mul_Bc!, A_rdiv_B!, A_rdiv_Bc!, Ac_ldiv_B!
-
 
     # The abstract base type
 
     abstract type AbstractPDMat{T<:Real} end
+
+    const HAVE_CHOLMOD = isdefined(SuiteSparse, :CHOLMOD)
 
     # source files
 
@@ -52,11 +50,11 @@ module PDMats
     include("utils.jl")
 
     include("pdmat.jl")
-#=
-    if isdefined(Base.SparseArrays, :CHOLMOD)
+
+    if HAVE_CHOLMOD
         include("pdsparsemat.jl")
     end
-=#
+
     include("pdiagmat.jl")
     include("scalmat.jl")
 

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -6,7 +6,7 @@ module PDMats
     using LinearAlgebra, SparseArrays
 
     import Base: +, *, \, /, ==, convert, inv, Matrix
-    import LinearAlgebra: logdet, diag, diagm, eigmax, eigmin
+    import LinearAlgebra: logdet, diag, eigmax, eigmin
 
     export
         # Types

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -3,9 +3,10 @@ __precompile__()
 module PDMats
 
     using Compat
+    using LinearAlgebra, SparseArrays
 
-    import Base: +, *, \, /, ==
-    import Base: full, logdet, inv, diag, diagm, eigmax, eigmin, convert
+    import Base: +, *, \, /, ==, convert, inv, Matrix
+    import LinearAlgebra: logdet, diag, diagm, eigmax, eigmin
 
     export
         # Types
@@ -36,9 +37,9 @@ module PDMats
         Xt_invA_X,
         test_pdmat
 
-    import Base.BLAS: nrm2, axpy!, gemv!, gemm, gemm!, trmv, trmv!, trmm, trmm!
-    import Base.LAPACK: trtrs!
-    import Base.LinAlg: A_ldiv_B!, A_mul_B!, A_mul_Bc!, A_rdiv_B!, A_rdiv_Bc!, Ac_ldiv_B!, Cholesky
+#    import Base.BLAS: nrm2, axpy!, gemv!, gemm, gemm!, trmv, trmv!, trmm, trmm!
+#    import Base.LAPACK: trtrs!
+    import LinearAlgebra: A_ldiv_B!, A_mul_B!, A_mul_Bc!, A_rdiv_B!, A_rdiv_Bc!, Ac_ldiv_B!
 
 
     # The abstract base type
@@ -51,9 +52,11 @@ module PDMats
     include("utils.jl")
 
     include("pdmat.jl")
+#=
     if isdefined(Base.SparseArrays, :CHOLMOD)
         include("pdsparsemat.jl")
     end
+=#
     include("pdiagmat.jl")
     include("scalmat.jl")
 

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -6,7 +6,6 @@ module PDMats
     using IterativeEigensolvers, LinearAlgebra, SparseArrays, SuiteSparse
 
     import Base: +, *, \, /, ==, convert, inv, Matrix
-    import LinearAlgebra: logdet, diag, eigmax, eigmin
 
     export
         # Types
@@ -46,7 +45,7 @@ module PDMats
 
     # source files
 
-    include("chol.jl")   # make Cholesky compatible with both Julia 0.3 & 0.4
+    include("chol.jl")
     include("utils.jl")
 
     include("pdmat.jl")

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -1,36 +1,36 @@
 
 # between pdmat and pdmat
 
-+(a::PDMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
-+(a::PDiagMat, b::AbstractPDMat) = PDMat(_adddiag!(full(b), a.diag))
-+(a::ScalMat, b::AbstractPDMat) = PDMat(_adddiag!(full(b), a.value))
-if isdefined(Base.SparseArrays, :CHOLMOD)
++(a::PDMat, b::AbstractPDMat) = PDMat(a.mat + Matrix(b))
++(a::PDiagMat, b::AbstractPDMat) = PDMat(_adddiag!(Matrix(b), a.diag))
++(a::ScalMat, b::AbstractPDMat) = PDMat(_adddiag!(Matrix(b), a.value))
+if isdefined(SparseArrays, :CHOLMOD)
     +(a::PDSparseMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
 end
 
 +(a::PDMat, b::PDMat) = PDMat(a.mat + b.mat)
 +(a::PDMat, b::PDiagMat) = PDMat(_adddiag(a.mat, b.diag))
 +(a::PDMat, b::ScalMat) = PDMat(_adddiag(a.mat, b.value))
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if isdefined(SparseArrays, :CHOLMOD)
     +(a::PDMat, b::PDSparseMat) = PDMat(a.mat + b.mat)
 end
 
 +(a::PDiagMat, b::PDMat) = PDMat(_adddiag(b.mat, a.diag))
 +(a::PDiagMat, b::PDiagMat) = PDiagMat(a.diag + b.diag)
 +(a::PDiagMat, b::ScalMat) = PDiagMat(a.diag .+ b.value)
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if isdefined(SparseArrays, :CHOLMOD)
     +(a::PDiagMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.diag))
 end
 
 +(a::ScalMat, b::PDMat) = PDMat(_adddiag(b.mat, a.value))
 +(a::ScalMat, b::PDiagMat) = PDiagMat(a.value .+ b.diag)
 +(a::ScalMat, b::ScalMat) = ScalMat(a.dim, a.value + b.value)
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if isdefined(SparseArrays, :CHOLMOD)
     +(a::ScalMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.value))
 end
 
-if isdefined(Base.SparseArrays, :CHOLMOD)
-    +(a::PDSparseMat, b::PDMat) = PDMat(full(a) + b.mat)
+if isdefined(SparseArrays, :CHOLMOD)
+    +(a::PDSparseMat, b::PDMat) = PDMat(Matrix(a) + b.mat)
     +(a::PDSparseMat, b::PDiagMat) = PDSparseMat(_adddiag(a.mat, b.diag))
     +(a::PDSparseMat, b::ScalMat) = PDSparseMat(_adddiag(a.mat, b.value))
     +(a::PDSparseMat, b::PDSparseMat) = PDSparseMat(a.mat + b.mat)
@@ -42,35 +42,35 @@ end
 +(a::AbstractPDMat, b::UniformScaling) = a + ScalMat(dim(a), b.λ)
 +(a::UniformScaling, b::AbstractPDMat) = ScalMat(dim(b), a.λ) + b
 
-pdadd(a::PDMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + full(b * c))
-pdadd(a::PDiagMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(full(b * c), a.diag, one(c)))
-pdadd(a::ScalMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(full(b * c), a.value))
-if isdefined(Base.SparseArrays, :CHOLMOD)
-    pdadd(a::PDSparseMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + full(b * c))
+pdadd(a::PDMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + Matrix(b * c))
+pdadd(a::PDiagMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(Matrix(b * c), a.diag, one(c)))
+pdadd(a::ScalMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(Matrix(b * c), a.value))
+if isdefined(SparseArrays, :CHOLMOD)
+    pdadd(a::PDSparseMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + Matrix(b * c))
 end
 
 pdadd(a::PDMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
 pdadd(a::PDMat, b::PDiagMat, c::Real) = PDMat(_adddiag(a.mat, b.diag, c))
 pdadd(a::PDMat, b::ScalMat, c::Real) = PDMat(_adddiag(a.mat, b.value * c))
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if isdefined(SparseArrays, :CHOLMOD)
     pdadd(a::PDMat, b::PDSparseMat, c::Real) = PDMat(a.mat + b.mat * c)
 end
 
 pdadd(a::PDiagMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.diag, one(c)))
 pdadd(a::PDiagMat, b::PDiagMat, c::Real) = PDiagMat(a.diag + b.diag * c)
 pdadd(a::PDiagMat, b::ScalMat, c::Real) = PDiagMat(a.diag .+ b.value * c)
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if isdefined(SparseArrays, :CHOLMOD)
     pdadd(a::PDiagMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.diag, one(c)))
 end
 
 pdadd(a::ScalMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.value))
 pdadd(a::ScalMat, b::PDiagMat, c::Real) = PDiagMat(a.value .+ b.diag * c)
 pdadd(a::ScalMat, b::ScalMat, c::Real) = ScalMat(a.dim, a.value + b.value * c)
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if isdefined(SparseArrays, :CHOLMOD)
     pdadd(a::ScalMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.value))
 end
 
-if isdefined(Base.SparseArrays, :CHOLMOD)
+if isdefined(SparseArrays, :CHOLMOD)
     pdadd(a::PDSparseMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
     pdadd(a::PDSparseMat, b::PDiagMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.diag, c))
     pdadd(a::PDSparseMat, b::ScalMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.value * c))

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -4,32 +4,32 @@
 +(a::PDMat, b::AbstractPDMat) = PDMat(a.mat + Matrix(b))
 +(a::PDiagMat, b::AbstractPDMat) = PDMat(_adddiag!(Matrix(b), a.diag))
 +(a::ScalMat, b::AbstractPDMat) = PDMat(_adddiag!(Matrix(b), a.value))
-if isdefined(SparseArrays, :CHOLMOD)
-    +(a::PDSparseMat, b::AbstractPDMat) = PDMat(a.mat + full(b))
+if HAVE_CHOLMOD
+    +(a::PDSparseMat, b::AbstractPDMat) = PDMat(a.mat + Matrix(b))
 end
 
 +(a::PDMat, b::PDMat) = PDMat(a.mat + b.mat)
 +(a::PDMat, b::PDiagMat) = PDMat(_adddiag(a.mat, b.diag))
 +(a::PDMat, b::ScalMat) = PDMat(_adddiag(a.mat, b.value))
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     +(a::PDMat, b::PDSparseMat) = PDMat(a.mat + b.mat)
 end
 
 +(a::PDiagMat, b::PDMat) = PDMat(_adddiag(b.mat, a.diag))
 +(a::PDiagMat, b::PDiagMat) = PDiagMat(a.diag + b.diag)
 +(a::PDiagMat, b::ScalMat) = PDiagMat(a.diag .+ b.value)
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     +(a::PDiagMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.diag))
 end
 
 +(a::ScalMat, b::PDMat) = PDMat(_adddiag(b.mat, a.value))
 +(a::ScalMat, b::PDiagMat) = PDiagMat(a.value .+ b.diag)
 +(a::ScalMat, b::ScalMat) = ScalMat(a.dim, a.value + b.value)
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     +(a::ScalMat, b::PDSparseMat) = PDSparseMat(_adddiag(b.mat, a.value))
 end
 
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     +(a::PDSparseMat, b::PDMat) = PDMat(Matrix(a) + b.mat)
     +(a::PDSparseMat, b::PDiagMat) = PDSparseMat(_adddiag(a.mat, b.diag))
     +(a::PDSparseMat, b::ScalMat) = PDSparseMat(_adddiag(a.mat, b.value))
@@ -45,32 +45,32 @@ end
 pdadd(a::PDMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + Matrix(b * c))
 pdadd(a::PDiagMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(Matrix(b * c), a.diag, one(c)))
 pdadd(a::ScalMat, b::AbstractPDMat, c::Real) = PDMat(_adddiag!(Matrix(b * c), a.value))
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::PDSparseMat, b::AbstractPDMat, c::Real) = PDMat(a.mat + Matrix(b * c))
 end
 
 pdadd(a::PDMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
 pdadd(a::PDMat, b::PDiagMat, c::Real) = PDMat(_adddiag(a.mat, b.diag, c))
 pdadd(a::PDMat, b::ScalMat, c::Real) = PDMat(_adddiag(a.mat, b.value * c))
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::PDMat, b::PDSparseMat, c::Real) = PDMat(a.mat + b.mat * c)
 end
 
 pdadd(a::PDiagMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.diag, one(c)))
 pdadd(a::PDiagMat, b::PDiagMat, c::Real) = PDiagMat(a.diag + b.diag * c)
 pdadd(a::PDiagMat, b::ScalMat, c::Real) = PDiagMat(a.diag .+ b.value * c)
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::PDiagMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.diag, one(c)))
 end
 
 pdadd(a::ScalMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.value))
 pdadd(a::ScalMat, b::PDiagMat, c::Real) = PDiagMat(a.value .+ b.diag * c)
 pdadd(a::ScalMat, b::ScalMat, c::Real) = ScalMat(a.dim, a.value + b.value * c)
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::ScalMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.value))
 end
 
-if isdefined(SparseArrays, :CHOLMOD)
+if HAVE_CHOLMOD
     pdadd(a::PDSparseMat, b::PDMat, c::Real) = PDMat(a.mat + b.mat * c)
     pdadd(a::PDSparseMat, b::PDiagMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.diag, c))
     pdadd(a::PDSparseMat, b::ScalMat, c::Real) = PDSparseMat(_adddiag(a.mat, b.value * c))

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -1,8 +1,10 @@
 CholType{T,S<:AbstractMatrix} = Cholesky{T,S}
 chol_lower(a::Matrix) = chol(a)'
 
+#=
 if isdefined(Base.SparseArrays, :CHOLMOD)
     CholTypeSparse{T} = SparseArrays.CHOLMOD.Factor{T}
 
     chol_lower(cf::CholTypeSparse) = cf[:L]
 end
+=#

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -1,10 +1,8 @@
 CholType{T,S<:AbstractMatrix} = Cholesky{T,S}
 chol_lower(a::Matrix) = chol(a)'
 
-#=
-if isdefined(Base.SparseArrays, :CHOLMOD)
-    CholTypeSparse{T} = SparseArrays.CHOLMOD.Factor{T}
+if HAVE_CHOLMOD
+    CholTypeSparse{T} = SuiteSparse.CHOLMOD.Factor{T}
 
-    chol_lower(cf::CholTypeSparse) = cf[:L]
+    chol_lower(cf::CholTypeSparse) = cf.L
 end
-=#

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,19 +1,11 @@
 # deprecated functions
 
-import Base: depwarn
+using Base: @deprecate
 
-function add!(a::Matrix, b::AbstractPDMat)
-    depwarn("add! is deprecated in favor of pdadd!", :add!)
-    pdadd!(a, b)
-end
+@deprecate add!(a::Matrix, b::AbstractPDMat) pdadd!(a, b)
 
-function add_scal!(a::Matrix, b::AbstractPDMat, c::Real)
-    depwarn("add! is deprecated in favor of pdadd!", :add_scal!)
-    pdadd!(a, b, c)
-end
+@deprecate add_scal!(a::Matrix, b::AbstractPDMat, c::Real) pdadd!(a, b, c)
 
-function add_scal(a::Matrix, b::AbstractPDMat, c::Real)
-    depwarn("add_scal is deprecated in favor of pdadd", :add_scal)
-    pdadd(a, b, c)
-end
+@deprecate add_scal(a::Matrix, b::AbstractPDMat, c::Real) pdadd(a, b, c)
 
+@deprecate full(x::AbstractPDMat) Matrix(x)

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -40,10 +40,10 @@ unwhiten(a::AbstractPDMat, x::StridedVecOrMat) = unwhiten!(similar(x), a, x)
 
 function quad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
-    quad!(Array{promote_type(T, S)}(size(x,2)), a, x)
+    quad!(Array{promote_type(T, S)}(uninitialized, size(x,2)), a, x)
 end
 
 function invquad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
-    invquad!(Array{promote_type(T, S)}(size(x,2)), a, x)
+    invquad!(Array{promote_type(T, S)}(uninitialized, size(x,2)), a, x)
 end

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -28,16 +28,59 @@ pdadd(a::Matrix{T}, b::AbstractPDMat{S}) where {T<:Real, S<:Real} = pdadd!(simil
 
 
 ## whiten and unwhiten
-
 whiten!(a::AbstractPDMat, x::StridedVecOrMat) = whiten!(x, a, x)
 unwhiten!(a::AbstractPDMat, x::StridedVecOrMat) = unwhiten!(x, a, x)
 
+"""
+    whiten(a::AbstractPDMat, x::StridedVecOrMat)
+    whiten!(a::AbstractPDMat, x::StridedVecOrMat)
+    whiten!(r::StridedVecOrMat, a::AbstractPDMat, x::StridedVecOrMat)
+    unwhiten(a::AbstractPDMat, x::StridedVecOrMat)
+    unwhiten!(a::AbstractPDMat, x::StridedVecOrMat)
+    unwhiten!(r::StridedVecOrMat, a::AbstractPDMat, x::StridedVecOrMat)
+
+Allocating and in-place versions of the `whiten`ing transform (or its inverse) defined by `a` applied to `x`
+
+If the covariance of `x` is `a` then the covariance of the result will be `I`.
+The name `whiten` indicates that this function transforms a correlated multivariate random
+variable to "white noise".
+
+```jldoctest
+julia> using PDMats
+
+julia> X = vcat(ones(4)', (1:4)')
+2×4 Array{Float64,2}:
+ 1.0  1.0  1.0  1.0
+ 1.0  2.0  3.0  4.0
+
+julia> a = PDMat(X * X')
+PDMat{Float64,Array{Float64,2}}(2, [4.0 10.0; 10.0 30.0], Cholesky{Float64,Array{Float64,2}}([2.0 5.0; 10.0 2.23607], 'U', 0))
+
+julia> W = whiten(a, X)
+2×4 Array{Float64,2}:
+  0.5       0.5       0.5       0.5    
+ -0.67082  -0.223607  0.223607  0.67082
+
+julia> W * W'
+2×2 Array{Float64,2}:
+ 1.0  0.0
+ 0.0  1.0
+```
+"""
 whiten(a::AbstractPDMat, x::StridedVecOrMat) = whiten!(similar(x), a, x)
 unwhiten(a::AbstractPDMat, x::StridedVecOrMat) = unwhiten!(similar(x), a, x)
 
 
 ## quad
 
+"""
+    quad(a::AbstractPDMat, x::StridedVecOrMat)
+
+Return the value of the quadratic form defined by `a` applied to `x`
+
+If `x` is a vector the quadratic form is `x' * a * x`.  If `x` is a matrix
+the quadratic form is applied column-wise.
+"""
 function quad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
     quad!(Array{promote_type(T, S)}(uninitialized, size(x,2)), a, x)

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -86,6 +86,17 @@ function quad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     quad!(Array{promote_type(T, S)}(uninitialized, size(x,2)), a, x)
 end
 
+
+"""
+    invquad(a::AbstractPDMat, x::StridedVecOrMat)
+
+Return the value of the quadratic form defined by `inv(a)` applied to `x`.
+
+For most `PDMat` types this is done in a way that does not require evaluation of `inv(a)`.
+
+If `x` is a vector the quadratic form is `x' * a * x`.  If `x` is a matrix
+the quadratic form is applied column-wise.
+"""
 function invquad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
     invquad!(Array{promote_type(T, S)}(uninitialized, size(x,2)), a, x)

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -12,17 +12,17 @@ function PDiagMat(v::AbstractVector,inv_v::AbstractVector)
   PDiagMat{eltype(v),typeof(v)}(length(v), v, inv_v)
 end
 
-PDiagMat(v::Vector) = PDiagMat(v, ones(v)./v)
+PDiagMat(v::Vector) = PDiagMat(v, inv.(v))
 
 ### Conversion
-convert(::Type{PDiagMat{T}},      a::PDiagMat) where {T<:Real} = PDiagMat(convert(AbstractArray{T}, a.diag))
-convert(::Type{AbstractArray{T}}, a::PDiagMat) where {T<:Real} = convert(PDiagMat{T}, a)
+Base.convert(::Type{PDiagMat{T}},      a::PDiagMat) where {T<:Real} = PDiagMat(convert(AbstractArray{T}, a.diag))
+Base.convert(::Type{AbstractArray{T}}, a::PDiagMat) where {T<:Real} = convert(PDiagMat{T}, a)
 
 ### Basics
 
 dim(a::PDiagMat) = a.dim
-full(a::PDiagMat) = diagm(a.diag)
-diag(a::PDiagMat) = copy(a.diag)
+Base.Matrix(a::PDiagMat) = diagm(a.diag)
+LinearAlgebra.diag(a::PDiagMat) = copy(a.diag)
 
 
 ### Arithmetics
@@ -44,10 +44,10 @@ end
 
 ### Algebra
 
-inv(a::PDiagMat) = PDiagMat(a.inv_diag, a.diag)
-logdet(a::PDiagMat) = sum(log, a.diag)
-eigmax(a::PDiagMat) = maximum(a.diag)
-eigmin(a::PDiagMat) = minimum(a.diag)
+Base.inv(a::PDiagMat) = PDiagMat(a.inv_diag, a.diag)
+LinearAlgebra.logdet(a::PDiagMat) = sum(log, a.diag)
+LinearAlgebra.eigmax(a::PDiagMat) = maximum(a.diag)
+LinearAlgebra.eigmin(a::PDiagMat) = minimum(a.diag)
 
 
 ### whiten and unwhiten

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -13,19 +13,19 @@ function PDMat(mat::AbstractMatrix,chol::CholType)
     PDMat{eltype(mat),typeof(mat)}(d, mat, chol)
 end
 
-PDMat(mat::Matrix) = PDMat(mat,cholfact(mat))
-PDMat(mat::Symmetric) = PDMat(full(mat))
-PDMat(fac::CholType) = PDMat(full(fac),fac)
+PDMat(mat::Matrix) = PDMat(mat, cholfact(mat))
+PDMat(mat::Symmetric) = PDMat(Matrix(mat))
+PDMat(fac::CholType) = PDMat(Matrix(fac),fac)
 
 ### Conversion
-convert(::Type{PDMat{T}},         a::PDMat) where {T<:Real} = PDMat(convert(AbstractArray{T}, a.mat))
-convert(::Type{AbstractArray{T}}, a::PDMat) where {T<:Real} = convert(PDMat{T}, a)
+Base.convert(::Type{PDMat{T}},         a::PDMat) where {T<:Real} = PDMat(convert(AbstractArray{T}, a.mat))
+Base.convert(::Type{AbstractArray{T}}, a::PDMat) where {T<:Real} = convert(PDMat{T}, a)
 
 ### Basics
 
 dim(a::PDMat) = a.dim
-full(a::PDMat) = copy(a.mat)
-diag(a::PDMat) = diag(a.mat)
+Base.Matrix(a::PDMat) = copy(a.mat)
+LinearAlgebra.diag(a::PDMat) = diag(a.mat)
 
 
 ### Arithmetics
@@ -42,10 +42,10 @@ end
 
 ### Algebra
 
-inv(a::PDMat) = PDMat(inv(a.chol))
-logdet(a::PDMat) = logdet(a.chol)
-eigmax(a::PDMat) = eigmax(a.mat)
-eigmin(a::PDMat) = eigmin(a.mat)
+Base.inv(a::PDMat) = PDMat(inv(a.chol))
+LinearAlgebra.logdet(a::PDMat) = logdet(a.chol)
+LinearAlgebra.eigmax(a::PDMat) = eigmax(a.mat)
+LinearAlgebra.eigmin(a::PDMat) = eigmin(a.mat)
 
 
 ### whiten and unwhiten

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -66,7 +66,18 @@ end
 quad(a::PDMat, x::StridedVector) = dot(x, a * x)
 invquad(a::PDMat, x::StridedVector) = dot(x, a \ x)
 
+"""
+    quad!(r::AbstractArray, a::AbstractPDMat, x::StridedMatrix)
+
+Overwrite `r` with the value of the quadratic form defined by `a` applied columnwise to `x`
+"""
 quad!(r::AbstractArray, a::PDMat, x::StridedMatrix) = colwise_dot!(r, x, a.mat * x)
+
+"""
+    invquad!(r::AbstractArray, a::AbstractPDMat, x::StridedMatrix)
+
+Overwrite `r` with the value of the quadratic form defined by `inv(a)` applied columnwise to `x`
+"""
 invquad!(r::AbstractArray, a::PDMat, x::StridedMatrix) = colwise_dot!(r, x, a.mat \ x)
 
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -22,8 +22,8 @@ convert(::Type{PDSparseMat{T}}, a::PDSparseMat) where {T<:Real} = PDSparseMat(co
 ### Basics
 
 dim(a::PDSparseMat) = a.dim
-full(a::PDSparseMat) = full(a.mat)
-diag(a::PDSparseMat) = diag(a.mat)
+Matrix(a::PDSparseMat) = Matrix(a.mat)
+LinearAlgebra.diag(a::PDSparseMat) = diag(a.mat)
 
 
 ### Arithmetics
@@ -41,10 +41,10 @@ end
 
 ### Algebra
 
-inv(a::PDSparseMat{T}) where {T<:Real} = PDMat( a\eye(T,a.dim) )
-logdet(a::PDSparseMat) = logdet(a.chol)
-eigmax(a::PDSparseMat{T}) where {T<:Real} = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:LM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
-eigmin(a::PDSparseMat{T}) where {T<:Real} = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:SM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
+Base.inv(a::PDSparseMat{T}) where {T<:Real} = PDMat( a\eye(T,a.dim) )
+LinearAlgebra.logdet(a::PDSparseMat) = logdet(a.chol)
+LinearAlgebra.eigmax(a::PDSparseMat{T}) where {T<:Real} = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:LM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
+LinearAlgebra.eigmin(a::PDSparseMat{T}) where {T<:Real} = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:SM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
 
 
 ### whiten and unwhiten
@@ -84,22 +84,22 @@ end
 
 function X_A_Xt(a::PDSparseMat, x::StridedMatrix)
     z = x*sparse(chol_lower(a.chol))
-    A_mul_Bt(z, z)
+    z * z'
 end
 
 
 function Xt_A_X(a::PDSparseMat, x::StridedMatrix)
-    z = At_mul_B(x, sparse(chol_lower(a.chol)))
-    A_mul_Bt(z, z)
+    z = x' * sparse(chol_lower(a.chol))
+    z * z'
 end
 
 
 function X_invA_Xt(a::PDSparseMat, x::StridedMatrix)
-    z = a \ x'
+    z = a.chol \ collect(x')
     x * z
 end
 
 function Xt_invA_X(a::PDSparseMat, x::StridedMatrix)
-    z = a \ x
-    At_mul_B(x, z)
+    z = a.chol \ x
+    x' * z
 end

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -17,12 +17,12 @@ PDSparseMat(mat::SparseMatrixCSC) = PDSparseMat(mat, cholfact(mat))
 PDSparseMat(fac::CholTypeSparse) = PDSparseMat(sparse(fac) |> x -> x*x', fac)
 
 ### Conversion
-convert(::Type{PDSparseMat{T}}, a::PDSparseMat) where {T<:Real} = PDSparseMat(convert(SparseMatrixCSC{T}, a.mat))
+Base.convert(::Type{PDSparseMat{T}}, a::PDSparseMat) where {T<:Real} = PDSparseMat(convert(SparseMatrixCSC{T}, a.mat))
 
 ### Basics
 
 dim(a::PDSparseMat) = a.dim
-Matrix(a::PDSparseMat) = Matrix(a.mat)
+Base.Matrix(a::PDSparseMat) = Matrix(a.mat)
 LinearAlgebra.diag(a::PDSparseMat) = diag(a.mat)
 
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -83,23 +83,23 @@ end
 ### tri products
 
 function X_A_Xt(a::PDSparseMat, x::StridedMatrix)
-    z = x*sparse(chol_lower(a.chol))
-    z * z'
+    z = x * sparse(chol_lower(a.chol))
+    z * transpose(z)
 end
 
 
 function Xt_A_X(a::PDSparseMat, x::StridedMatrix)
-    z = x' * sparse(chol_lower(a.chol))
-    z * z'
+    z = transpose(x) * sparse(chol_lower(a.chol))
+    z * transpose(z)
 end
 
 
 function X_invA_Xt(a::PDSparseMat, x::StridedMatrix)
-    z = a.chol \ collect(x')
+    z = a.chol \ collect(transpose(x))
     x * z
 end
 
 function Xt_invA_X(a::PDSparseMat, x::StridedMatrix)
     z = a.chol \ x
-    x' * z
+    transpose(x) * z
 end

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -6,7 +6,7 @@ struct ScalMat{T<:Real} <: AbstractPDMat{T}
   inv_value::T
 end
 
-ScalMat(d::Int,v::Real) = ScalMat{typeof(one(v)/v)}(d, v, one(v) / v)
+ScalMat(d::Int,v::Real) = ScalMat{typeof(inv(v))}(d, v, inv(v))
 
 ### Conversion
 convert(::Type{ScalMat{T}}, a::ScalMat) where {T<:Real} = ScalMat(a.dim, T(a.value), T(a.inv_value))

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -9,8 +9,8 @@ end
 ScalMat(d::Int,v::Real) = ScalMat{typeof(inv(v))}(d, v, inv(v))
 
 ### Conversion
-convert(::Type{ScalMat{T}}, a::ScalMat) where {T<:Real} = ScalMat(a.dim, T(a.value), T(a.inv_value))
-convert(::Type{AbstractArray{T}}, a::ScalMat) where {T<:Real} = convert(ScalMat{T}, a)
+Base.convert(::Type{ScalMat{T}}, a::ScalMat) where {T<:Real} = ScalMat(a.dim, T(a.value), T(a.inv_value))
+Base.convert(::Type{AbstractArray{T}}, a::ScalMat) where {T<:Real} = convert(ScalMat{T}, a)
 
 ### Basics
 

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -11,7 +11,7 @@ using Compat: view
 function test_pdmat(C::AbstractPDMat, Cmat::Matrix;
                     verbose::Int=2,             # the level to display intermediate steps
                     cmat_eq::Bool=false,        # require Cmat and full(C) to be exactly equal
-                    t_diag::Bool=true,          # whethet to test diag method
+                    t_diag::Bool=true,          # whether to test diag method
                     t_scale::Bool=true,         # whether to test scaling
                     t_add::Bool=true,           # whether to test pdadd
                     t_logdet::Bool=true,        # whether to test logdet method
@@ -74,16 +74,16 @@ function pdtest_basics(C::AbstractPDMat, Cmat::Matrix, d::Int, verbose::Int)
 
     _pdt(verbose, "eltype")
     @test eltype(C) == eltype(Cmat)
-    @test eltype(typeof(C)) == eltype(typeof(Cmat))
+#    @test eltype(typeof(C)) == eltype(typeof(Cmat))
 end
 
 
 function pdtest_cmat(C::AbstractPDMat, Cmat::Matrix, cmat_eq::Bool, verbose::Int)
     _pdt(verbose, "full")
     if cmat_eq
-        @test full(C) == Cmat
+        @test Matrix(C) == Cmat
     else
-        @test full(C) ≈ Cmat
+        @test Matrix(C) ≈ Cmat
     end
 end
 
@@ -100,8 +100,8 @@ end
 
 function pdtest_scale(C::AbstractPDMat, Cmat::Matrix, verbose::Int)
     _pdt(verbose, "scale")
-    @test full(C * convert(eltype(C),2)) ≈ Cmat * convert(eltype(C),2)
-    @test full(convert(eltype(C),2) * C) ≈ convert(eltype(C),2) * Cmat
+    @test Matrix(C * convert(eltype(C),2)) ≈ Cmat * convert(eltype(C),2)
+    @test Matrix(convert(eltype(C),2) * C) ≈ convert(eltype(C),2) * Cmat
 end
 
 
@@ -230,7 +230,7 @@ function pdtest_whiten(C::AbstractPDMat, Cmat::Matrix, verbose::Int)
 
     _pdt(verbose, "whiten")
     Z = whiten(C, Y)
-    @test Z * Z' ≈ eye(eltype(C),d)
+    @test Z * Z' ≈ Matrix{eltype(C)}(I, d, d)
     for i = 1:d
         @test whiten(C, Y[:,i]) ≈ Z[:,i]
     end
@@ -253,6 +253,6 @@ function pdtest_whiten(C::AbstractPDMat, Cmat::Matrix, verbose::Int)
     @test X ≈ X2
 
     _pdt(verbose, "whiten-unwhiten")
-    @test unwhiten(C, whiten(C, eye(eltype(C),d))) ≈ eye(eltype(C),d)
-    @test whiten(C, unwhiten(C, eye(eltype(C),d))) ≈ eye(eltype(C),d)
+    @test unwhiten(C, whiten(C, Matrix{eltype(C)}(I, d, d))) ≈ Matrix{eltype(C)}(I, d, d)
+    @test whiten(C, unwhiten(C, Matrix{eltype(C)}(I, d, d))) ≈ Matrix{eltype(C)}(I, d, d)
 end

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -9,7 +9,7 @@ using Test: @test
 ## driver function
 function test_pdmat(C::AbstractPDMat, Cmat::Matrix;
                     verbose::Int=2,             # the level to display intermediate steps
-                    cmat_eq::Bool=false,        # require Cmat and full(C) to be exactly equal
+                    cmat_eq::Bool=false,        # require Cmat and Matrix(C) to be exactly equal
                     t_diag::Bool=true,          # whether to test diag method
                     t_scale::Bool=true,         # whether to test scaling
                     t_add::Bool=true,           # whether to test pdadd

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -4,8 +4,7 @@
 #       the implementation of a subtype of AbstractPDMat
 #
 
-import Compat.Test: @test
-using Compat: view
+using Test: @test
 
 ## driver function
 function test_pdmat(C::AbstractPDMat, Cmat::Matrix;

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -23,7 +23,7 @@ function test_pdmat(C::AbstractPDMat, Cmat::Matrix;
                     )
 
     d = size(Cmat, 1)
-    verbose >= 1 && print_with_color(:blue, "Testing $(typeof(C)) with dim = $d\n")
+    verbose >= 1 && printstyled("Testing $(typeof(C)) with dim = $d\n", color=:blue)
 
     pdtest_basics(C, Cmat, d, verbose)
     pdtest_cmat(C, Cmat, cmat_eq, verbose)
@@ -52,7 +52,7 @@ end
 
 ## core testing functions
 
-_pdt(vb::Int, s) = (vb >= 2 && print_with_color(:green, "    .. testing $s\n"))
+_pdt(vb::Int, s) = (vb >= 2 && printstyled("    .. testing $s\n", color=:green))
 
 
 function pdtest_basics(C::AbstractPDMat, Cmat::Matrix, d::Int, verbose::Int)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,7 +7,7 @@ macro check_argdims(cond)
     end
 end
 
-_rcopy!(r::StridedVecOrMat, x::StridedVecOrMat) = (r === x || copy!(r, x); r)
+_rcopy!(r::StridedVecOrMat, x::StridedVecOrMat) = (r === x || copyto!(r, x); r)
 
 
 function _addscal!(r::Matrix, a::Matrix, b::Union{Matrix, SparseMatrixCSC}, c::Real)

--- a/test/addition.jl
+++ b/test/addition.jl
@@ -22,16 +22,16 @@ for T in [Float64,Float32]
   for p1 in pmats, p2 in pmats
       pr = p1 + p2
       @test size(pr) == size(p1)
-      @test full(pr) ≈ full(p1) + full(p2)
+      @test Matrix(pr) ≈ Matrix(p1) + Matrix(p2)
 
       pr = pdadd(p1, p2, convert(T,1.5))
       @test size(pr) == size(p1)
-      @test full(pr) ≈ full(p1) + full(p2) * convert(T,1.5)
+      @test Matrix(pr) ≈ Matrix(p1) + Matrix(p2) * convert(T,1.5)
   end
 
   for p1 in pmats
         pr = p1 + pm4
         @test size(pr) == size(p1)
-        @test full(pr) ≈ full(p1) + pm4
+        @test Matrix(pr) ≈ Matrix(p1) + pm4
   end
 end

--- a/test/addition.jl
+++ b/test/addition.jl
@@ -14,9 +14,10 @@ for T in [Float64,Float32]
   pm2 = PDiagMat(V)
   pm3 = ScalMat(3,X)
   pm4 = X*I
+#=
   pm5 = PDSparseMat(sparse(M))
-
-  pmats = Any[pm1, pm2, pm3, pm5]
+=#
+  pmats = Any[pm1, pm2, pm3] #, pm5]
 
   for p1 in pmats, p2 in pmats
       pr = p1 + p2

--- a/test/addition.jl
+++ b/test/addition.jl
@@ -5,7 +5,7 @@ using Compat.Test
 
 for T in [Float64,Float32]
 
-  print_with_color(:blue, "Testing addition with eltype = $T\n")
+  printstyled("Testing addition with eltype = $T\n", color=:blue)
   M = convert(Array{T,2},[4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
   V = convert(Array{T,1},[1.5, 2.5, 2.0])
   X = convert(T,2.0)
@@ -14,9 +14,8 @@ for T in [Float64,Float32]
   pm2 = PDiagMat(V)
   pm3 = ScalMat(3,X)
   pm4 = X*I
-#=
   pm5 = PDSparseMat(sparse(M))
-=#
+
   pmats = Any[pm1, pm2, pm3] #, pm5]
 
   for p1 in pmats, p2 in pmats

--- a/test/generics.jl
+++ b/test/generics.jl
@@ -4,7 +4,7 @@ using LinearAlgebra, PDMats
 using Test
 
 # test scalar multiplication 
-print_with_color(:blue, "Testing scalar multiplication\n")
+printstyled("Testing scalar multiplication\n", color=:blue)
 pm1 = PDMat(Matrix(1.0I, 3, 3))
 pm2 = PDiagMat(ones(3))
 pm3 = ScalMat(3,1)

--- a/test/generics.jl
+++ b/test/generics.jl
@@ -1,15 +1,15 @@
 
 # test operators with pd matrix types
-using PDMats
-using Compat.Test
+using LinearAlgebra, PDMats
+using Test
 
 # test scalar multiplication 
 print_with_color(:blue, "Testing scalar multiplication\n")
-pm1 = PDMat(eye(3))
+pm1 = PDMat(Matrix(1.0I, 3, 3))
 pm2 = PDiagMat(ones(3))
 pm3 = ScalMat(3,1)
 
-pm1a = PDMat(3.0 .* eye(3))
+pm1a = PDMat(Matrix(3.0I, 3, 3))
 pm2a = PDiagMat(3.0 .* ones(3))
 pm3a = ScalMat(3, 3)
 

--- a/test/generics.jl
+++ b/test/generics.jl
@@ -17,8 +17,8 @@ pmats = Any[pm1, pm2, pm3]
 pmatsa= Any[pm1a,pm2a,pm3a]
 
 for i in 1:length(pmats)
-    @test full(3.0 * pmats[i]) == full(pmatsa[i])
-    @test full(pmats[i] * 3.0) == full(pmatsa[i])
-    @test full(3 * pmats[i])   == full(pmatsa[i])
-    @test full(pmats[i] * 3)   == full(pmatsa[i])
+    @test Matrix(3.0 * pmats[i]) == Matrix(pmatsa[i])
+    @test Matrix(pmats[i] * 3.0) == Matrix(pmatsa[i])
+    @test Matrix(3 * pmats[i])   == Matrix(pmatsa[i])
+    @test Matrix(pmats[i] * 3)   == Matrix(pmatsa[i])
 end

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -1,5 +1,5 @@
 # test pd matrix types
-using LinearAlgebra, PDMats
+using LinearAlgebra, PDMats, SparseArrays
 using Test
 
 call_test_pdmat(p::AbstractPDMat,m::Matrix) = test_pdmat(p,m,cmat_eq=true,verbose=1)
@@ -12,10 +12,8 @@ for T in [Float64, Float32]
     @test PDiagMat(d,d).inv_diag == PDiagMat(d).inv_diag
     x = one(T)
     @test ScalMat(2,x,x).inv_value == ScalMat(2,x).inv_value
-#=
-    s = speye(T,2,2)
+    s = SparseMatrixCSC{T}(I, 2, 2)
     @test PDSparseMat(s, cholfact(s)).mat == PDSparseMat(s).mat == PDSparseMat(cholfact(s)).mat
-=#
 
     #test the functionality
     M = convert(Array{T,2}, [4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
@@ -25,9 +23,7 @@ for T in [Float64, Float32]
     call_test_pdmat(PDMat(M), M) #tests of PDMat
     call_test_pdmat(PDiagMat(V), Matrix(Diagonal(V))) #tests of PDiagMat
     call_test_pdmat(ScalMat(3,x), x*Matrix{T}(I, 3, 3)) #tests of ScalMat
-#=
     call_test_pdmat(PDSparseMat(sparse(M)), M)
-=#
 end
 
 m = Matrix{Float32}(I, 2, 2)
@@ -39,7 +35,5 @@ m = ones(Float32,2)
 x = one(Float32); d = 4
 @test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
 @test convert(AbstractArray{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
-#=
-s = speye(Float32, 2, 2)
+s = SparseMatrixCSC{Float32}(I, 2, 2)
 @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat
-=#

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -1,19 +1,21 @@
 # test pd matrix types
-using PDMats
-using Compat.Test
+using LinearAlgebra, PDMats
+using Test
 
 call_test_pdmat(p::AbstractPDMat,m::Matrix) = test_pdmat(p,m,cmat_eq=true,verbose=1)
 
 for T in [Float64, Float32]
     #test that all external constructors are accessible
-    m = eye(T,2)
+    m = Matrix{T}(I, 2, 2)
     @test PDMat(m, cholfact(m)).mat == PDMat(Symmetric(m)).mat == PDMat(m).mat == PDMat(cholfact(m)).mat
     d = ones(T,2)
     @test PDiagMat(d,d).inv_diag == PDiagMat(d).inv_diag
     x = one(T)
     @test ScalMat(2,x,x).inv_value == ScalMat(2,x).inv_value
+#=
     s = speye(T,2,2)
     @test PDSparseMat(s, cholfact(s)).mat == PDSparseMat(s).mat == PDSparseMat(cholfact(s)).mat
+=#
 
     #test the functionality
     M = convert(Array{T,2}, [4. -2. -1.; -2. 5. -1.; -1. -1. 6.])
@@ -22,11 +24,13 @@ for T in [Float64, Float32]
 
     call_test_pdmat(PDMat(M), M) #tests of PDMat
     call_test_pdmat(PDiagMat(V), diagm(V)) #tests of PDiagMat
-    call_test_pdmat(ScalMat(3,x), x*eye(T,3)) #tests of ScalMat
+    call_test_pdmat(ScalMat(3,x), x*Matrix{T}(I, 3, 3)) #tests of ScalMat
+#=
     call_test_pdmat(PDSparseMat(sparse(M)), M)
+=#
 end
 
-m = eye(Float32,2)
+m = Matrix{Float32}(I, 2, 2)
 @test convert(PDMat{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
 @test convert(AbstractArray{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
 m = ones(Float32,2)
@@ -35,5 +39,7 @@ m = ones(Float32,2)
 x = one(Float32); d = 4
 @test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
 @test convert(AbstractArray{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
+#=
 s = speye(Float32, 2, 2)
 @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat
+=#

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -23,7 +23,7 @@ for T in [Float64, Float32]
     X = convert(T,2.0)
 
     call_test_pdmat(PDMat(M), M) #tests of PDMat
-    call_test_pdmat(PDiagMat(V), diagm(V)) #tests of PDiagMat
+    call_test_pdmat(PDiagMat(V), Matrix(Diagonal(V))) #tests of PDiagMat
     call_test_pdmat(ScalMat(3,x), x*Matrix{T}(I, 3, 3)) #tests of ScalMat
 #=
     call_test_pdmat(PDSparseMat(sparse(M)), M)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,5 +5,3 @@ for t in tests
 	println("* $t ")
 	include("$t.jl")
 end
-
-


### PR DESCRIPTION
This is a work in progress on which I would appreciate comments.  I'm not sure what to do about sparse matrices.  At present in v0.7.0-DEV the CHOLMOD types and methods are in the SuiteSparse stdlib package but I don't know if they will stay there, because of the [L]GPL issues.  For the time being I have disabled the sparse parts.

As a parallel project I am working on switching the documentation to the Documenter package.  I see that a few vestiges have crept in here.

What I want to get done is

- [ ] `Base.LinAlg` -> `LinearAlgebra`
- [ ] method definitions for foreign generics use fully qualified names
- [ ] `full()` -> `Matrix()`
- [ ] `A[ct]_mul_B[ct]!` -> `mul!`; same for ldiv and rdiv