### PR TITLE
Use `Compat.undef` instead of `uninitialized`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.7.0-DEV.3449
-Compat 0.33
+Compat 0.61.0

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -83,7 +83,7 @@ the quadratic form is applied column-wise.
 """
 function quad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
-    quad!(Array{promote_type(T, S)}(uninitialized, size(x,2)), a, x)
+    quad!(Array{promote_type(T, S)}(Compat.undef, size(x,2)), a, x)
 end
 
 
@@ -99,5 +99,5 @@ the quadratic form is applied column-wise.
 """
 function invquad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
-    invquad!(Array{promote_type(T, S)}(uninitialized, size(x,2)), a, x)
+    invquad!(Array{promote_type(T, S)}(Compat.undef, size(x,2)), a, x)
 end

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -83,7 +83,7 @@ the quadratic form is applied column-wise.
 """
 function quad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
-    quad!(Array{promote_type(T, S)}(Compat.undef, size(x,2)), a, x)
+    quad!(Array{promote_type(T, S)}(undef, size(x,2)), a, x)
 end
 
 
@@ -99,5 +99,5 @@ the quadratic form is applied column-wise.
 """
 function invquad(a::AbstractPDMat{T}, x::StridedMatrix{S}) where {T<:Real, S<:Real}
     @check_argdims dim(a) == size(x, 1)
-    invquad!(Array{promote_type(T, S)}(Compat.undef, size(x,2)), a, x)
+    invquad!(Array{promote_type(T, S)}(undef, size(x,2)), a, x)
 end


### PR DESCRIPTION
Cut down on the noise when testing on v0.7