### PR TITLE
Update to cholesky name and accessors

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7.0-DEV.3449
+julia 0.7.0-DEV.5190 # for cholesky function
 Compat 0.61.0

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -1,5 +1,5 @@
 CholType{T,S<:AbstractMatrix} = Cholesky{T,S}
-chol_lower(a::Matrix) = chol(a)'
+chol_lower(a::Matrix) = cholesky(a).L
 
 if HAVE_CHOLMOD
     CholTypeSparse{T} = SuiteSparse.CHOLMOD.Factor{T}

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -13,7 +13,7 @@ function PDMat(mat::AbstractMatrix,chol::CholType)
     PDMat{eltype(mat),typeof(mat)}(d, mat, chol)
 end
 
-PDMat(mat::Matrix) = PDMat(mat, cholfact(mat))
+PDMat(mat::Matrix) = PDMat(mat, cholesky(mat))
 PDMat(mat::Symmetric) = PDMat(Matrix(mat))
 PDMat(fac::CholType) = PDMat(Matrix(fac), fac)
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -13,7 +13,7 @@ function PDSparseMat(mat::AbstractSparseMatrix,chol::CholTypeSparse)
     PDSparseMat{eltype(mat),typeof(mat)}(d, mat, chol)
 end
 
-PDSparseMat(mat::SparseMatrixCSC) = PDSparseMat(mat, cholfact(mat))
+PDSparseMat(mat::SparseMatrixCSC) = PDSparseMat(mat, cholesky(mat))
 PDSparseMat(fac::CholTypeSparse) = PDSparseMat(sparse(fac) |> x -> x*x', fac)
 
 ### Conversion

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -222,7 +222,7 @@ end
 
 function pdtest_whiten(C::AbstractPDMat, Cmat::Matrix, verbose::Int)
     Y = chol_lower(Cmat)
-    Q = qr(convert(Array{eltype(C),2},randn(size(Cmat))))[1]
+    Q = qr(convert(Array{eltype(C),2},randn(size(Cmat)))).Q
     Y = Y * Q'                    # generate a matrix Y such that Y * Y' = C
     @test Y * Y' ≈ Cmat
     d = dim(C)

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -7,13 +7,13 @@ call_test_pdmat(p::AbstractPDMat,m::Matrix) = test_pdmat(p,m,cmat_eq=true,verbos
 for T in [Float64, Float32]
     #test that all external constructors are accessible
     m = Matrix{T}(I, 2, 2)
-    @test PDMat(m, cholfact(m)).mat == PDMat(Symmetric(m)).mat == PDMat(m).mat == PDMat(cholfact(m)).mat
+    @test PDMat(m, cholesky(m)).mat == PDMat(Symmetric(m)).mat == PDMat(m).mat == PDMat(cholesky(m)).mat
     d = ones(T,2)
     @test PDiagMat(d,d).inv_diag == PDiagMat(d).inv_diag
     x = one(T)
     @test ScalMat(2,x,x).inv_value == ScalMat(2,x).inv_value
     s = SparseMatrixCSC{T}(I, 2, 2)
-    @test PDSparseMat(s, cholfact(s)).mat == PDSparseMat(s).mat == PDSparseMat(cholfact(s)).mat
+    @test PDSparseMat(s, cholesky(s)).mat == PDSparseMat(s).mat == PDSparseMat(cholesky(s)).mat
 
     #test the functionality
     M = convert(Array{T,2}, [4. -2. -1.; -2. 5. -1.; -1. -1. 6.])


### PR DESCRIPTION
- Use `cholesky` in preference to `chol` or `cholfact`.
- Require version of Julia with that name
- Use accessor function to obtain `Q` from a `qr` decomposition.