### PR TITLE
Make whiten! and unwhiten! type stable

### DIFF
--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -55,12 +55,14 @@ LinearAlgebra.eigmin(a::PDMat) = eigmin(a.mat)
 
 function whiten!(r::StridedVecOrMat, a::PDMat, x::StridedVecOrMat)
     cf = a.chol.UL
-    ldiv!(istriu(cf) ? transpose(cf) : cf, _rcopy!(r, x))
+    v = _rcopy!(r, x)
+    istriu(cf) ? ldiv!(transpose(cf), v) : ldiv!(cf, v)
 end
 
 function unwhiten!(r::StridedVecOrMat, a::PDMat, x::StridedVecOrMat)
     cf = a.chol.UL
-    lmul!(istriu(cf) ? transpose(cf) : cf, _rcopy!(r, x))
+    v = _rcopy!(r, x)
+    istriu(cf) ? lmul!(transpose(cf), v) : lmul!(cf, v)
 end
 
 

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -37,3 +37,10 @@ x = one(Float32); d = 4
 @test convert(AbstractArray{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
 s = SparseMatrixCSC{Float32}(I, 2, 2)
 @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat
+
+# type stability of whiten! and unwhiten!
+a = PDMat([1 0.5; 0.5 1])
+@inferred whiten!(ones(2), a, ones(2))
+@inferred unwhiten!(ones(2), a, ones(2))
+@inferred whiten(a, ones(2))
+@inferred unwhiten(a, ones(2))


### PR DESCRIPTION
Fixes the problem with type stability of `whiten!` and `unwhiten!` which propagates, e.g. to multivariate random number generation in Distributions.jl.