### PR TITLE
Remove input eltype restriction to inner constructor of PDiagMat

### DIFF
--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -6,7 +6,7 @@ struct PDiagMat{T<:Real,V<:AbstractVector} <: AbstractPDMat{T}
     diag::V
     inv_diag::V
 
-    PDiagMat{T,S}(d::Int,v::AbstractVector{T},inv_v::AbstractVector{T}) where {T,S} =
+    PDiagMat{T,S}(d::Int,v::AbstractVector,inv_v::AbstractVector) where {T,S} =
         new{T,S}(d,v,inv_v)
 end
 


### PR DESCRIPTION
This PR removes the restriction on the `eltype`s of the inputs to the `PDiagMat` constructor. This allows conversion to take place inside with compatible types as opposed to just throwing an error. This was causing trouble in [Turing.jl](https://github.com/TuringLang/Turing.jl).