### PR TITLE
more stable quad and invquad with vectors

### DIFF
--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -68,8 +68,15 @@ end
 
 ### quadratic forms
 
-quad(a::PDMat, x::AbstractVector) = dot(x, a * x)
-invquad(a::PDMat, x::AbstractVector) = dot(x, a \ x)
+function quad(a::PDMat, x::AbstractVector)
+    z = a.chol.U * x
+    dot(z, z)
+end
+
+function invquad(a::PDMat, x::AbstractVector)
+    z = a.chol.L \ x
+    dot(z, z)
+end
 
 """
     quad!(r::AbstractArray, a::AbstractPDMat, x::StridedMatrix)

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -68,15 +68,8 @@ end
 
 ### quadratic forms
 
-function quad(a::PDMat, x::AbstractVector)
-    z = a.chol.U * x
-    dot(z, z)
-end
-
-function invquad(a::PDMat, x::AbstractVector)
-    z = a.chol.L \ x
-    dot(z, z)
-end
+quad(a::PDMat, x::AbstractVector) = sum(abs2, a.chol.U * x)
+invquad(a::PDMat, x::AbstractVector) = sum(abs2, a.chol.L \ x)
 
 """
     quad!(r::AbstractArray, a::AbstractPDMat, x::StridedMatrix)


### PR DESCRIPTION
More stable versions of `quad` and `invquad` for the case of `(a::PDMat, x::AbstractVector)`.
This addresses issue #94 

`quad` uses the fact that: 
x'*a*x = x'*U'*U*x = (U*x)'*(U*x)

`invquad` uses the fact that:
x'*inv(a)*x = x'*inv(L*L')*x
                 = x'*inv(L')*inv(L)*x
                 = x'*inv(L)'*inv(L)*x
                 = (L \ x)'*(L \ x)