### PR TITLE
add kron

### DIFF
--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -2,7 +2,7 @@ module PDMats
 
     using LinearAlgebra, SparseArrays, SuiteSparse
 
-    import Base: +, *, \, /, ==, convert, inv, Matrix
+    import Base: +, *, \, /, ==, convert, inv, Matrix, kron
 
     export
         # Types

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -49,7 +49,7 @@ Base.inv(a::PDMat) = PDMat(inv(a.chol))
 LinearAlgebra.logdet(a::PDMat) = logdet(a.chol)
 LinearAlgebra.eigmax(a::PDMat) = eigmax(a.mat)
 LinearAlgebra.eigmin(a::PDMat) = eigmin(a.mat)
-
+Base.kron(A::PDMat, B::PDMat) = PDMat(kron(A.mat, B.mat), Cholesky(kron(A.chol.U, B.chol.U), 'U', A.chol.info))
 
 ### whiten and unwhiten
 

--- a/test/kron.jl
+++ b/test/kron.jl
@@ -1,0 +1,22 @@
+using PDMats
+using Test
+
+n = 4
+m = 7
+
+for T in [Float64, Float32]
+    X = randn(T, n, n)
+    Y = randn(T, m, m)
+    A = X * X'
+    B = Y * Y'
+    AkB = kron(A, B)
+    PDA = PDMat(A)
+    PDB = PDMat(B)
+    PDAkB1 = PDMat(AkB)
+    PDAkB2 = kron(PDA, PDB)
+    @test PDAkB1.dim == PDAkB2.dim
+    @test PDAkB1.mat ≈ PDAkB2.mat
+    @test PDAkB1.chol.L ≈ PDAkB2.chol.L
+    @test PDAkB1.chol.U ≈ PDAkB2.chol.U
+    @test Matrix(PDAkB2.chol) ≈ PDAkB2.mat
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-tests = ["pdmtypes", "addition", "generics"]
+tests = ["pdmtypes", "addition", "generics", "kron"]
 println("Running tests ...")
 
 for t in tests


### PR DESCRIPTION
The kronecker product of positive definite matrices is positive definite, and the cholesky factor of a kronecker product is the kronecker product of the cholesky factors. So this PR adds

```julia
Base.kron(A::PDMat, B::PDMat) = PDMat(kron(A.mat, B.mat), Cholesky(kron(A.chol.U, B.chol.U), 'U', A.chol.info))
```

This functionality would be used to improve two spots in `Distributions.jl` where a covariance matrix is computed as the kronecker product of two `PDMat` instances, but we currently ignore the `PDMat` nature of the factors: [here](https://github.com/JuliaStats/Distributions.jl/blob/d00c780d680993519cf3dd0ce2b71dadd477afcf/src/matrix/matrixnormal.jl#L125) and [here](https://github.com/JuliaStats/Distributions.jl/blob/d00c780d680993519cf3dd0ce2b71dadd477afcf/src/matrix/matrixtdist.jl#L165).

Turns out that directly supplying both `mat` and `chol` is faster than just supplying `chol` and letting `mat` be computed from it. MWE:

```julia
using LinearAlgebra, PDMats

X = randn(7, 7)
Y = randn(11, 11)
PDA = PDMat(X * X')
PDB = PDMat(Y * Y')

kron1(A::PDMat, B::PDMat) = PDMat(Cholesky(kron(A.chol.U, B.chol.U), 'U', A.chol.info))
kron2(A::PDMat, B::PDMat) = PDMat(kron(A.mat, B.mat), Cholesky(kron(A.chol.U, B.chol.U), 'U', A.chol.info))

julia> @time PDMat(kron(PDA.mat, PDB.mat))
  0.000183 seconds (13 allocations: 93.203 KiB)

julia> @time kron1(PDA, PDB)
  0.000176 seconds (15 allocations: 139.625 KiB)

julia> @time kron2(PDA, PDB)
  0.000108 seconds (12 allocations: 93.156 KiB)
```