### PR TITLE
Bump version for next release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.9.7"
+version = "0.9.8"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"


### PR DESCRIPTION
I'd like to get a release tagged with the changes from #101.  I've bumped the
patch version since AFAICT none of the changes since 0.9.7 are breaking (#95 and
#100 just provide more stable/efficient implementations of existing
functionality, although they may produce numerically different results, I'm not
sure).