### PR TITLE
Making AbstractPDMat inherit from AbstractMatrix

### DIFF
--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -37,7 +37,7 @@ module PDMats
     """
     The base type for positive definite matrices.
     """
-    abstract type AbstractPDMat{T<:Real} end
+    abstract type AbstractPDMat{T<:Real} <: AbstractMatrix{T} end
 
     const HAVE_CHOLMOD = isdefined(SuiteSparse, :CHOLMOD)
 

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -27,6 +27,8 @@ dim(a::PDiagMat) = a.dim
 Base.Matrix(a::PDiagMat) = Matrix(Diagonal(a.diag))
 LinearAlgebra.diag(a::PDiagMat) = copy(a.diag)
 LinearAlgebra.cholesky(a::PDiagMat) = cholesky(Diagonal(a.diag))
+Base.getindex(a::PDiagMat{T},i::Integer) where {T} = i%a.dim == (i÷a.dim+1) ? a.diag[i%a.dim] : zero(0)
+Base.getindex(a::PDiagMat{T},i::Integer,j::Integer) where {T} = i == j ? a.diag[i] : zero(T)
 
 ### Arithmetics
 

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -27,6 +27,10 @@ dim(a::PDiagMat) = a.dim
 Base.Matrix(a::PDiagMat) = Matrix(Diagonal(a.diag))
 LinearAlgebra.diag(a::PDiagMat) = copy(a.diag)
 LinearAlgebra.cholesky(a::PDiagMat) = cholesky(Diagonal(a.diag))
+
+### Inheriting from AbstractMatrix
+
+Base.size(a::PDiagMat) = (a.dim,a.dim)
 Base.getindex(a::PDiagMat{T},i::Integer) where {T} = i%a.dim == (i÷a.dim+1) ? a.diag[i%a.dim] : zero(T)
 Base.getindex(a::PDiagMat{T},i::Integer,j::Integer) where {T} = i == j ? a.diag[i] : zero(T)
 

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -49,6 +49,8 @@ end
 *(a::PDiagMat, c::T) where {T<:Real} = PDiagMat(a.diag * c)
 *(a::PDiagMat, x::StridedVecOrMat) = a.diag .* x
 \(a::PDiagMat, x::StridedVecOrMat) = a.inv_diag .* x
+/(x::StridedVecOrMat, a::PDiagMat) = a.inv_diag .* x
+
 Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat( vcat([A.diag[i] * B.diag for i in 1:dim(A)]...) )
 
 ### Algebra

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -27,7 +27,7 @@ dim(a::PDiagMat) = a.dim
 Base.Matrix(a::PDiagMat) = Matrix(Diagonal(a.diag))
 LinearAlgebra.diag(a::PDiagMat) = copy(a.diag)
 LinearAlgebra.cholesky(a::PDiagMat) = cholesky(Diagonal(a.diag))
-Base.getindex(a::PDiagMat{T},i::Integer) where {T} = i%a.dim == (i÷a.dim+1) ? a.diag[i%a.dim] : zero(0)
+Base.getindex(a::PDiagMat{T},i::Integer) where {T} = i%a.dim == (i÷a.dim+1) ? a.diag[i%a.dim] : zero(T)
 Base.getindex(a::PDiagMat{T},i::Integer,j::Integer) where {T} = i == j ? a.diag[i] : zero(T)
 
 ### Arithmetics

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -30,8 +30,8 @@ LinearAlgebra.cholesky(a::PDiagMat) = cholesky(Diagonal(a.diag))
 
 ### Inheriting from AbstractMatrix
 
-Base.size(a::PDiagMat) = (a.dim,a.dim)
-Base.getindex(a::PDiagMat{T},i::Integer) where {T} = i%a.dim == (i÷a.dim+1) ? a.diag[i%a.dim] : zero(T)
+Base.size(a::PDiagMat) = (a.dim, a.dim)
+Base.getindex(a::PDiagMat{T},i::Integer) where {T} = i % a.dim == (i ÷ a.dim + 1) ? a.diag[i % a.dim] : zero(T)
 Base.getindex(a::PDiagMat{T},i::Integer,j::Integer) where {T} = i == j ? a.diag[i] : zero(T)
 
 ### Arithmetics

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -47,7 +47,8 @@ function pdadd!(r::Matrix, a::Matrix, b::PDiagMat, c)
 end
 
 *(a::PDiagMat, c::T) where {T<:Real} = PDiagMat(a.diag * c)
-*(a::PDiagMat, x::AbstractVecOrMat) = a.diag .* x
+*(a::PDiagMat, x::AbstractVector) = a.diag .* x
+*(a::PDiagMat, x::AbstractMatrix) = a.diag .* x
 \(a::PDiagMat, x::AbstractVecOrMat) = a.inv_diag .* x
 /(x::AbstractVecOrMat, a::PDiagMat) = a.inv_diag .* x
 Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat( vcat([A.diag[i] * B.diag for i in 1:dim(A)]...) )

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -31,8 +31,12 @@ dim(a::PDMat) = a.dim
 Base.Matrix(a::PDMat) = copy(a.mat)
 LinearAlgebra.diag(a::PDMat) = diag(a.mat)
 LinearAlgebra.cholesky(a::PDMat) = a.chol
-Base.getindex(a::PDMat,i::Integer) = getindex(a.mat,i)
-Base.getindex(a::PDMat,i::Integer,j::Integer) = getindex(a.mat,i,j)
+
+### Inheriting from AbstractMatrix
+
+Base.size(a::PDMat) = size(a.mat)
+Base.getindex(a::PDMat,i::Int) = getindex(a.mat,i)
+Base.getindex(a::PDMat,i::Int,j::Int) = getindex(a.mat,i,j)
 
 ### Arithmetics
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -35,8 +35,8 @@ LinearAlgebra.cholesky(a::PDMat) = a.chol
 ### Inheriting from AbstractMatrix
 
 Base.size(a::PDMat) = size(a.mat)
-Base.getindex(a::PDMat,i::Int) = getindex(a.mat,i)
-Base.getindex(a::PDMat,i::Int,j::Int) = getindex(a.mat,i,j)
+Base.getindex(a::PDMat, i::Int) = getindex(a.mat, i)
+Base.getindex(a::PDMat, I::Vararg{Int, N}) where {N} = getindex(a.mat, I...)
 
 ### Arithmetics
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -49,7 +49,7 @@ end
 *(a::PDMat, x::AbstractVector{T}) where {T} = a.mat * x
 *(a::PDMat, x::AbstractMatrix{T}) where {T} = a.mat * x
 \(a::PDMat, x::AbstractVecOrMat) = a.chol \ x
-
+/(x::AbstractVecOrMat, a::PDMat) = x / a.chol
 
 ### Algebra
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -31,7 +31,8 @@ dim(a::PDMat) = a.dim
 Base.Matrix(a::PDMat) = copy(a.mat)
 LinearAlgebra.diag(a::PDMat) = diag(a.mat)
 LinearAlgebra.cholesky(a::PDMat) = a.chol
-
+Base.getindex(a::PDMat,i::Integer) = getindex(a.mat,i)
+Base.getindex(a::PDMat,i::Integer,j::Integer) = getindex(a.mat,i,j)
 
 ### Arithmetics
 
@@ -41,7 +42,8 @@ function pdadd!(r::Matrix, a::Matrix, b::PDMat, c)
 end
 
 *(a::PDMat{S}, c::T) where {S<:Real, T<:Real} = PDMat(a.mat * c)
-*(a::PDMat, x::AbstractVecOrMat) = a.mat * x
+*(a::PDMat, x::AbstractVector{T}) where {T} = a.mat * x
+*(a::PDMat, x::AbstractMatrix{T}) where {T} = a.mat * x
 \(a::PDMat, x::AbstractVecOrMat) = a.chol \ x
 
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -49,7 +49,7 @@ end
 *(a::PDSparseMat, c::T) where {T<:Real} = PDSparseMat(a.mat * c)
 *(a::PDSparseMat, x::StridedVecOrMat) = a.mat * x
 \(a::PDSparseMat{T}, x::StridedVecOrMat{T}) where {T<:Real} = convert(Array{T},a.chol \ convert(Array{Float64},x)) #to avoid limitations in sparse factorization library CHOLMOD, see e.g., julia issue #14076
-
+/(x::StridedVecOrMat{T}, a::PDSparseMat{T}) where {T<:Real} = convert(Array{T},convert(Array{Float64},x) / a.chol )
 
 ### Algebra
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -31,7 +31,8 @@ dim(a::PDSparseMat) = a.dim
 Base.Matrix(a::PDSparseMat) = Matrix(a.mat)
 LinearAlgebra.diag(a::PDSparseMat) = diag(a.mat)
 LinearAlgebra.cholesky(a::PDSparseMat) = a.chol
-
+Base.getindex(a::PDSparseMat,i::Integer) = getindex(a.mat,i)
+Base.getindex(a::PDSparseMat,i::Integer,j::Integer) = getindex(a.mat,i,j)
 
 ### Arithmetics
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -34,9 +34,9 @@ LinearAlgebra.cholesky(a::PDSparseMat) = a.chol
 
 ### Inheriting from AbstractMatrix
 
-Base.size(a::PDSparseMat) = (a.dim,a.dim)
-Base.getindex(a::PDSparseMat,i::Integer) = getindex(a.mat,i)
-Base.getindex(a::PDSparseMat,i::Integer,j::Integer) = getindex(a.mat,i,j)
+Base.size(a::PDSparseMat) = (a.dim, a.dim)
+Base.getindex(a::PDSparseMat,i::Integer) = getindex(a.mat, i)
+Base.getindex(a::PDSparseMat,I::Vararg{Int, N}) where {N} = getindex(a.mat, I...)
 
 ### Arithmetics
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -31,6 +31,10 @@ dim(a::PDSparseMat) = a.dim
 Base.Matrix(a::PDSparseMat) = Matrix(a.mat)
 LinearAlgebra.diag(a::PDSparseMat) = diag(a.mat)
 LinearAlgebra.cholesky(a::PDSparseMat) = a.chol
+
+### Inheriting from AbstractMatrix
+
+Base.size(a::PDSparseMat) = (a.dim,a.dim)
 Base.getindex(a::PDSparseMat,i::Integer) = getindex(a.mat,i)
 Base.getindex(a::PDSparseMat,i::Integer,j::Integer) = getindex(a.mat,i,j)
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -19,6 +19,8 @@ dim(a::ScalMat) = a.dim
 Base.Matrix(a::ScalMat) = Matrix(Diagonal(fill(a.value, a.dim)))
 LinearAlgebra.diag(a::ScalMat) = fill(a.value, a.dim)
 LinearAlgebra.cholesky(a::ScalMat) = cholesky(Diagonal(fill(a.value, a.dim)))
+Base.getindex(a::ScalMat{T},i::Integer) where {T} = i%a.dim == (i÷a.dim+1) ? a.value : zero(T)
+Base.getindex(a::ScalMat{T},i::Integer,j::Integer) where {T} = i == j ? a.value : zero(T)
 
 ### Arithmetics
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -19,6 +19,10 @@ dim(a::ScalMat) = a.dim
 Base.Matrix(a::ScalMat) = Matrix(Diagonal(fill(a.value, a.dim)))
 LinearAlgebra.diag(a::ScalMat) = fill(a.value, a.dim)
 LinearAlgebra.cholesky(a::ScalMat) = cholesky(Diagonal(fill(a.value, a.dim)))
+
+### Inheriting from AbstractMatrix
+
+Base.size(a::ScalMat) = (a.dim,a.dim)
 Base.getindex(a::ScalMat{T},i::Integer) where {T} = i%a.dim == (i÷a.dim+1) ? a.value : zero(T)
 Base.getindex(a::ScalMat{T},i::Integer,j::Integer) where {T} = i == j ? a.value : zero(T)
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -40,7 +40,8 @@ end
 
 *(a::ScalMat, c::T) where {T<:Real} = ScalMat(a.dim, a.value * c)
 /(a::ScalMat{T}, c::T) where {T<:Real} = ScalMat(a.dim, a.value / c)
-*(a::ScalMat, x::AbstractVecOrMat) = a.value * x
+*(a::ScalMat, x::AbstractVector) = a.value * x
+*(a::ScalMat, x::AbstractMatrix) = a.value * x
 \(a::ScalMat, x::AbstractVecOrMat) = a.inv_value * x
 /(x::AbstractVecOrMat, a::ScalMat) = a.inv_value * x
 Base.kron(A::ScalMat, B::ScalMat) = ScalMat( dim(A) * dim(B), A.value * B.value )

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -22,9 +22,9 @@ LinearAlgebra.cholesky(a::ScalMat) = cholesky(Diagonal(fill(a.value, a.dim)))
 
 ### Inheriting from AbstractMatrix
 
-Base.size(a::ScalMat) = (a.dim,a.dim)
-Base.getindex(a::ScalMat{T},i::Integer) where {T} = i%a.dim == (i÷a.dim+1) ? a.value : zero(T)
-Base.getindex(a::ScalMat{T},i::Integer,j::Integer) where {T} = i == j ? a.value : zero(T)
+Base.size(a::ScalMat) = (a.dim, a.dim)
+Base.getindex(a::ScalMat{T}, i::Integer) where {T} = i%a.dim == (i ÷ a.dim + 1) ? a.value : zero(T)
+Base.getindex(a::ScalMat{T}, i::Integer, j::Integer) where {T} = i == j ? a.value : zero(T)
 
 ### Arithmetics
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -42,6 +42,7 @@ end
 /(a::ScalMat{T}, c::T) where {T<:Real} = ScalMat(a.dim, a.value / c)
 *(a::ScalMat, x::StridedVecOrMat) = a.value * x
 \(a::ScalMat, x::StridedVecOrMat) = a.inv_value * x
+/(x::StridedVecOrMat, a::ScalMat) = a.inv_value * x
 Base.kron(A::ScalMat, B::ScalMat) = ScalMat( dim(A) * dim(B), A.value * B.value )
 
 ### Algebra


### PR DESCRIPTION
Following issue #40 
Implemented `getindex` for all types for a nicer display of the PDMats