### PR TITLE
More strided -> abstract

### DIFF
--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -41,8 +41,8 @@ function pdadd!(r::Matrix, a::Matrix, b::PDiagMat, c)
 end
 
 *(a::PDiagMat, c::T) where {T<:Real} = PDiagMat(a.diag * c)
-*(a::PDiagMat, x::StridedVecOrMat) = a.diag .* x
-\(a::PDiagMat, x::StridedVecOrMat) = a.inv_diag .* x
+*(a::PDiagMat, x::AbstractVecOrMat) = a.diag .* x
+\(a::PDiagMat, x::AbstractVecOrMat) = a.inv_diag .* x
 Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat( vcat([A.diag[i] * B.diag for i in 1:dim(A)]...) )
 
 ### Algebra
@@ -84,8 +84,8 @@ unwhiten!(r::StridedMatrix, a::PDiagMat, x::StridedMatrix) =
 
 ### quadratic forms
 
-quad(a::PDiagMat, x::StridedVector) = wsumsq(a.diag, x)
-invquad(a::PDiagMat, x::StridedVector) = wsumsq(a.inv_diag, x)
+quad(a::PDiagMat, x::AbstractVector) = wsumsq(a.diag, x)
+invquad(a::PDiagMat, x::AbstractVector) = wsumsq(a.inv_diag, x)
 
 function quad!(r::AbstractArray, a::PDiagMat, x::StridedMatrix)
     m, n = size(x)

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -34,8 +34,8 @@ end
 
 *(a::ScalMat, c::T) where {T<:Real} = ScalMat(a.dim, a.value * c)
 /(a::ScalMat{T}, c::T) where {T<:Real} = ScalMat(a.dim, a.value / c)
-*(a::ScalMat, x::StridedVecOrMat) = a.value * x
-\(a::ScalMat, x::StridedVecOrMat) = a.inv_value * x
+*(a::ScalMat, x::AbstractVecOrMat) = a.value * x
+\(a::ScalMat, x::AbstractVecOrMat) = a.inv_value * x
 Base.kron(A::ScalMat, B::ScalMat) = ScalMat( dim(A) * dim(B), A.value * B.value )
 
 ### Algebra


### PR DESCRIPTION
As was mentioned in #89 or in #90, it's not clear why operations like `\` require `Strided` vectors or matrices, and it's causing problems in `Distributions.jl`. Density evaluations for `MatrixNormal` and `MatrixTDist` involve things like `S \ A'`, but the `Strided` requirement means you get an error because `A'` is `Adjoint`.