### PR TITLE
Remove eigmin and eigmax definitions for PDSparseMat and thereby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ os:
   - osx
 
 julia:
-  - 0.7
   - 1.0
+  - 1
   - nightly
 
 notifications:

--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,10 @@ uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
 version = "0.9.12"
 
 [deps]
-Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Arpack = ">=0.2"
 julia = "0.7, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -9,4 +9,4 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -58,8 +58,6 @@ module PDMats
     include("generics.jl")
     include("addition.jl")
 
-    include("testutils.jl")
-
     include("deprecates.jl")
 
 end # module

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -1,5 +1,3 @@
-using Arpack
-
 """
 Sparse positive definite matrix together with a Cholesky factorization object.
 """
@@ -50,9 +48,6 @@ end
 
 Base.inv(a::PDSparseMat{T}) where {T<:Real} = PDMat( a\eye(T,a.dim) )
 LinearAlgebra.logdet(a::PDSparseMat) = logdet(a.chol)
-LinearAlgebra.eigmax(a::PDSparseMat{T}) where {T<:Real} = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:LM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
-LinearAlgebra.eigmin(a::PDSparseMat{T}) where {T<:Real} = convert(T,eigs(convert(SparseMatrixCSC{Float64,Int},a.mat), which=:SM, nev=1, ritzvec=false)[1][1]) #to avoid type instability issues in eigs, see e.g., julia issue #13929
-
 
 ### whiten and unwhiten
 

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -2,8 +2,6 @@
 using LinearAlgebra, PDMats, SparseArrays, SuiteSparse
 using Test
 
-call_test_pdmat(p::AbstractPDMat,m::Matrix) = test_pdmat(p,m,cmat_eq=true,verbose=1)
-
 for T in [Float64, Float32]
     #test that all external constructors are accessible
     m = Matrix{T}(I, 2, 2)
@@ -20,10 +18,10 @@ for T in [Float64, Float32]
     V = convert(Array{T,1}, [1.5, 2.5, 2.0])
     X = convert(T,2.0)
 
-    call_test_pdmat(PDMat(M), M) #tests of PDMat
-    call_test_pdmat(PDiagMat(V), Matrix(Diagonal(V))) #tests of PDiagMat
-    call_test_pdmat(ScalMat(3,x), x*Matrix{T}(I, 3, 3)) #tests of ScalMat
-    call_test_pdmat(PDSparseMat(sparse(M)), M)
+    test_pdmat(PDMat(M), M,                        cmat_eq=true, verbose=1) #tests of PDMat
+    test_pdmat(PDiagMat(V), Matrix(Diagonal(V)),   cmat_eq=true, verbose=1) #tests of PDiagMat
+    test_pdmat(ScalMat(3,x), x*Matrix{T}(I, 3, 3), cmat_eq=true, verbose=1) #tests of ScalMat
+    test_pdmat(PDSparseMat(sparse(M)), M,          cmat_eq=true, verbose=1, t_eig=false)
 end
 
 m = Matrix{Float32}(I, 2, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+include("testutils.jl")
 tests = ["pdmtypes", "addition", "generics", "kron"]
 println("Running tests ...")
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -4,8 +4,9 @@
 #       the implementation of a subtype of AbstractPDMat
 #
 
-using Test: @test
+using PDMats, SuiteSparse, Test
 
+const HAVE_CHOLMOD = isdefined(SuiteSparse, :CHOLMOD)
 const PDMatType = HAVE_CHOLMOD ? Union{PDMat, PDSparseMat, PDiagMat} : Union{PDMat, PDiagMat}
 
 ## driver function
@@ -244,7 +245,7 @@ end
 
 
 function pdtest_whiten(C::AbstractPDMat, Cmat::Matrix, verbose::Int)
-    Y = chol_lower(Cmat)
+    Y = PDMats.chol_lower(Cmat)
     Q = qr(convert(Array{eltype(C),2},randn(size(Cmat)))).Q
     Y = Y * Q'                    # generate a matrix Y such that Y * Y' = C
     @test Y * Y' ≈ Cmat


### PR DESCRIPTION
stop depending on Arpack. The Arpack dependency sometimes causes some problems on some platforms and since Distributions depend on PDMats it means that most users end up depending on Arpack even though they never compute `eigmax` or `eigmin` of a sparse matrix even indirectly.