### PR TITLE
PDMat: convert Matrix type to the same Cholesky type

### DIFF
--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -9,11 +9,11 @@ struct PDMat{T<:Real,S<:AbstractMatrix} <: AbstractPDMat{T}
     PDMat{T,S}(d::Int,m::AbstractMatrix{T},c::CholType{T,S}) where {T,S} = new{T,S}(d,m,c)
 end
 
-function PDMat(mat::AbstractMatrix,chol::CholType)
+function PDMat(mat::AbstractMatrix,chol::CholType{T,S}) where {T,S}
     d = size(mat, 1)
     size(chol, 1) == d ||
         throw(DimensionMismatch("Dimensions of mat and chol are inconsistent."))
-    PDMat{eltype(mat),typeof(mat)}(d, mat, chol)
+    PDMat{T,S}(d, convert(S, mat), chol)
 end
 
 PDMat(mat::Matrix) = PDMat(mat, cholesky(mat))

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -48,3 +48,5 @@ a = PDMat([1 0.5; 0.5 1])
 @inferred whiten(a, ones(2))
 @inferred unwhiten(a, ones(2))
 
+# convert Matrix type to the same Cholesky type (#117)
+@test PDMat([1 0; 0 1]) == [1.0 0.0; 0.0 1.0]


### PR DESCRIPTION
This addresses #98 where the original Matrix type (e.g., `Matrix{Int}`) can differ from the type returned by `Cholesky` (e.g., `Matrix{Float64}`). Therefore, we simply convert the Matrix type to the same paremetric types already converted by `Cholesky`.

Previously, this failed:
```julia
PDMat([1 0; 0 1])
```

This also addresses https://github.com/JuliaStats/Distributions.jl/issues/1004 (where my original problem started).