### PR TITLE
[Breaking] Make inverting a PDSparseMat throw an error

### DIFF
--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -51,7 +51,7 @@ end
 
 ### Algebra
 
-Base.inv(a::PDSparseMat{T}) where {T<:Real} = PDMat( a\eye(T,a.dim) )
+Base.inv(a::PDSparseMat{T}) where {T<:Real} = PDMat(inv(a.mat))
 LinearAlgebra.logdet(a::PDSparseMat) = logdet(a.chol)
 
 ### whiten and unwhiten


### PR DESCRIPTION
Alter the inv() method for PDSparseMat to fall through to the inv() method of its underlying matrix.  If that is a SparseMatrixCSC, an error will be thrown asking the user to convert to a dense matrix first (the default behavior in LinearAlgebra).  This would address https://github.com/JuliaStats/PDMats.jl/issues/87.

I considered writing a more `PDMats`-specific error message (e.g. "ERROR: The inverse of a sparse matrix can often be dense and can cause the computer to run out of memory. If you are sure you have enough memory, please convert your matrix to a dense matrix, for instance using `inv(PDMat(Matrix(J)))`".  However, making the method fall through to whatever is defined for the underlying matrix type allows for the possibility someone will one day write a sparse matrix type that does have a sparse inverse.  In that case, inverting a `PDSparseMat` wrapping such a matrix will "just work."