### PR TITLE
Add defaults for `isposdef` and `ishermitian`

### DIFF
--- a/src/generics.jl
+++ b/src/generics.jl
@@ -2,9 +2,6 @@
 
 ## Basic functions
 
-Base.eltype(a::AbstractPDMat{T}) where {T<:Real} = T
-Base.eltype(::Type{AbstractPDMat{T}}) where {T<:Real} = T
-Base.ndims(a::AbstractPDMat) = 2
 Base.size(a::AbstractPDMat) = (dim(a), dim(a))
 Base.size(a::AbstractPDMat, i::Integer) = 1 <= i <= 2 ? dim(a) : 1
 Base.length(a::AbstractPDMat) = abs2(dim(a))

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -24,6 +24,9 @@ pdadd(a::Matrix{T}, b::AbstractPDMat{S}) where {T<:Real, S<:Real} = pdadd!(simil
 /(a::AbstractPDMat, c::T) where {T<:Real} = a * inv(c)
 Base.kron(A::AbstractPDMat, B::AbstractPDMat) = PDMat(kron(Matrix(A), Matrix(B)))
 
+# LinearAlgebra
+LinearAlgebra.isposdef(::AbstractPDMat) = true
+LinearAlgebra.ishermitian(::AbstractPDMat) = true
 
 ## whiten and unwhiten
 whiten!(a::AbstractPDMat, x::StridedVecOrMat) = whiten!(x, a, x)

--- a/test/generics.jl
+++ b/test/generics.jl
@@ -23,7 +23,7 @@ for i in 1:length(pmats)
     @test Matrix(pmats[i] * 3)   == Matrix(pmatsa[i])
 end
 
-# issue #123
+# issue #121
 @test isposdef(PDMat([1.0 0.0; 0.0 1.0]))
 @test isposdef(PDiagMat([1.0, 1.0]))
 @test isposdef(ScalMat(2, 3.0))

--- a/test/generics.jl
+++ b/test/generics.jl
@@ -22,3 +22,8 @@ for i in 1:length(pmats)
     @test Matrix(3 * pmats[i])   == Matrix(pmatsa[i])
     @test Matrix(pmats[i] * 3)   == Matrix(pmatsa[i])
 end
+
+# issue #123
+@test isposdef(PDMat([1.0 0.0; 0.0 1.0]))
+@test isposdef(PDiagMat([1.0, 1.0]))
+@test isposdef(ScalMat(2, 3.0))

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -79,6 +79,12 @@ function pdtest_basics(C::AbstractPDMat, Cmat::Matrix, d::Int, verbose::Int)
     _pdt(verbose, "eltype")
     @test eltype(C) == eltype(Cmat)
 #    @test eltype(typeof(C)) == eltype(typeof(Cmat))
+  
+    _pdt(verbose, "isposdef")
+    @test isposdef(C)
+  
+    _pdt(verbose, "ishermitian")
+    @test ishermitian(C)
 end
 
 


### PR DESCRIPTION
This PR adds generic definitions of `LinearAlgebra.isposdef` and `LinearAlgebra.ishermitian`. It also removes `Base.eltype` and `Base.ndims` definitions which are not needed anymore since `AbstractPDMat{T} <: AbstractMatrix{T}`.

Fixes https://github.com/JuliaStats/PDMats.jl/issues/121. Fixes https://github.com/JuliaStats/PDMats.jl/issues/118.

I am not completely sure what's the best way to test these definitions (in particular `ishermitian`) - maybe I should add at least the failing examples for `isposdef`?