### PR TITLE
Clean exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,6 @@ unwhiten(a, x)      # inverse of whitening transform. `x` can be a vector or
 unwhiten!(a, x)     # un-whitening transform inplace, updating `x`.
 
 unwhiten!(r, a, x)  # write the transformed result to `r`.
-
-test_pdmat(a, amat)     # test the correctness of implementation, given an
-                        # instance of some sub-type of `AbstractPDMat`, and
-                        # a corresponding full matrix.
-                        #
-                        # Note: this function is provided for the developers
-                        # who want to define their own customized sub types.
 ```
 
 

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -14,15 +14,12 @@ module PDMats
 
         # Functions
         dim,
-        full,
         whiten,
         whiten!,
         unwhiten,
         unwhiten!,
         pdadd,
         pdadd!,
-        add_scal,
-        add_scal!,
         quad,
         quad!,
         invquad,
@@ -30,8 +27,7 @@ module PDMats
         X_A_Xt,
         Xt_A_X,
         X_invA_Xt,
-        Xt_invA_X,
-        test_pdmat
+        Xt_invA_X
 
 
     """


### PR DESCRIPTION
It seems some functions (listed in `src/deprecates.jl`) were deprecated a long time ago but not removed. This PR removes them from the README and removes explicit exports of these functions such that `deprecates.jl` can be removed more easily in the next breaking release. For the time being, the functions are still exported by the `@deprecate` macro.