### PR TITLE
Don't promote to `Matrix` with `PDMats` 1-arg constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,8 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 julia = "1"
 
 [extras]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["StaticArrays", "Test"]

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -52,7 +52,8 @@ end
 *(a::PDiagMat, x::AbstractVector) = a.diag .* x
 *(a::PDiagMat, x::AbstractMatrix) = a.diag .* x
 \(a::PDiagMat, x::AbstractVecOrMat) = a.inv_diag .* x
-/(x::AbstractVecOrMat, a::PDiagMat) = a.inv_diag .* x
+/(x::AbstractVector, a::PDiagMat) = a.inv_diag .* x
+/(x::AbstractMatrix, a::PDiagMat) = transpose(a.inv_diag) .* x
 Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat( vcat([A.diag[i] * B.diag for i in 1:dim(A)]...) )
 
 ### Algebra

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -16,8 +16,7 @@ function PDMat(mat::AbstractMatrix,chol::CholType{T,S}) where {T,S}
     PDMat{T,S}(d, convert(S, mat), chol)
 end
 
-PDMat(mat::Matrix) = PDMat(mat, cholesky(mat))
-PDMat(mat::Symmetric) = PDMat(Matrix(mat))
+PDMat(mat::AbstractMatrix) = PDMat(mat, cholesky(mat))
 PDMat(fac::CholType) = PDMat(Matrix(fac), fac)
 
 ### Conversion

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 include("testutils.jl")
-tests = ["pdmtypes", "addition", "generics", "kron"]
+tests = ["pdmtypes", "addition", "generics", "kron", "staticarrays"]
 println("Running tests ...")
 
 for t in tests

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -1,0 +1,19 @@
+using StaticArrays
+
+@testset "StaticArrays" begin
+    X = @SMatrix rand(10,4);
+    S = @SMatrix(randn(4,7)) |> x -> Symmetric(x * x');
+    PDS = PDMat(S)
+    @test isbits(PDS)
+    @test isbits(X / PDS)
+    @test isbits(PDS \ X')
+    @test (X / PDS) ≈ Matrix(X) / Matrix(S)
+    @test (PDS \ X') ≈ Matrix(S) \ Matrix(X')
+
+    D = PDiagMat(@SVector(rand(4)))
+    @test isbits(D)
+    @test isbits(X / D)
+    @test isbits(D \ X')
+    @test (X / D) ≈ Matrix(X) / Matrix(D)
+    @test (D \ X') ≈ Matrix(D) \ Matrix(X')
+end


### PR DESCRIPTION
This should improve support for `StaticArrays`, for example.