### PR TITLE
Fix logdet(PDiagMat(zeros(0)))

### DIFF
--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -58,7 +58,11 @@ Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat( vcat([A.diag[i] * B.diag for i i
 ### Algebra
 
 Base.inv(a::PDiagMat) = PDiagMat(a.inv_diag, a.diag)
-LinearAlgebra.logdet(a::PDiagMat) = sum(log, a.diag)
+if VERSION < v"1.6"
+    LinearAlgebra.logdet(a::PDiagMat) = length(a.diag) == 0 ? zero(eltype(a.diag)) : sum(log, a.diag)
+else
+    LinearAlgebra.logdet(a::PDiagMat) = sum(log, a.diag; init=zero(eltype(a.diag)))
+end
 LinearAlgebra.eigmax(a::PDiagMat) = maximum(a.diag)
 LinearAlgebra.eigmin(a::PDiagMat) = minimum(a.diag)
 

--- a/test/kron.jl
+++ b/test/kron.jl
@@ -1,7 +1,8 @@
 using PDMats
 using Test
+using LinearAlgebra: LinearAlgebra
 
-_randPDMat(T, n) = (X = randn(T, n, n); PDMat(X * X'))
+_randPDMat(T, n) = (X = randn(T, n, n); PDMat(X * X' + LinearAlgebra.I))
 _randPDiagMat(T, n) = PDiagMat(rand(T, n))
 _randScalMat(T, n) = ScalMat(n, rand(T))
 function _pd_compare(A::AbstractPDMat, B::AbstractPDMat)

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -38,6 +38,10 @@ x = one(Float32); d = 4
 s = SparseMatrixCSC{Float32}(I, 2, 2)
 @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat
 
+Z = zeros(0, 0)
+test_pdmat(PDMat(Z), Z; t_eig=false)
+test_pdmat(PDiagMat(diag(Z)), Z; t_eig=false)
+
 # no-op conversion with correct eltype (#101)
 X = PDMat((Y->Y'Y)(randn(Float32, 4, 4)))
 @test convert(AbstractArray{Float32}, X) === X


### PR DESCRIPTION
Resolves #138.

~The `init` keyword argument to `sum` is only available from julia 1.6, so there's a fallback implementation for older versions.~
Edit: `init` keyword isn't type-stable, anyways, so dropping the version-branching.