### PR TITLE
Fix PDiagMat when inv(v) isn't a subtype of v

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -11,3 +11,5 @@ using Base: @deprecate
 @deprecate full(x::AbstractPDMat) Matrix(x)
 
 @deprecate CholType Cholesky
+
+@deprecate PDiagMat{T,S}(d::Int,v::AbstractVector,inv_v::AbstractVector) where {T,S} PDiagMat{T,S}(d::Int,v::AbstractVector) where {T,S}

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -1,21 +1,22 @@
 """
 Positive definite diagonal matrix.
 """
-struct PDiagMat{T<:Real,V<:AbstractVector} <: AbstractPDMat{T}
+struct PDiagMat{T<:Real,V<:AbstractVector,I<:AbstractVector} <: AbstractPDMat{T}
     dim::Int
     diag::V
-    inv_diag::V
+    inv_diag::I
 
-    PDiagMat{T,S}(d::Int,v::AbstractVector,inv_v::AbstractVector) where {T,S} =
-        new{T,S}(d,v,inv_v)
+    PDiagMat{T,S,I}(d::Int,v::AbstractVector,inv_v::AbstractVector) where {T,S,I} =
+        new{T,S,I}(d,v,inv_v)
+    PDiagMat{T,S}(d::Int,v::AbstractVector,inv_v::AbstractVector) where {T,S} = PDiagMat{T,S,S}(d,v,inv_v)
 end
 
-function PDiagMat(v::A,inv_v::B) where {A <: AbstractVector, B <: AbstractVector}
+function PDiagMat(v::AbstractVector,inv_v::AbstractVector)
     @check_argdims length(v) == length(inv_v)
-    PDiagMat{eltype(v),Union{A,B}}(length(v), v, inv_v)
+    PDiagMat{eltype(v),typeof(v),typeof(inv_v)}(length(v), v, inv_v)
 end
 
-PDiagMat(v::AbstractVector) = PDiagMat(v, inv.(v))
+PDiagMat(v::AbstractVector) = PDiagMat{eltype(v),typeof(v), typeof(inv.(v))}(length(v), v, inv.(v))
 
 ### Conversion
 Base.convert(::Type{PDiagMat{T}},      a::PDiagMat) where {T<:Real} = PDiagMat(convert(AbstractArray{T}, a.diag))

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -10,9 +10,9 @@ struct PDiagMat{T<:Real,V<:AbstractVector} <: AbstractPDMat{T}
         new{T,S}(d,v,inv_v)
 end
 
-function PDiagMat(v::AbstractVector,inv_v::AbstractVector)
+function PDiagMat(v::A,inv_v::B) where {A <: AbstractVector, B <: AbstractVector}
     @check_argdims length(v) == length(inv_v)
-    PDiagMat{eltype(v),typeof(v)}(length(v), v, inv_v)
+    PDiagMat{eltype(v),Union{A,B}}(length(v), v, inv_v)
 end
 
 PDiagMat(v::AbstractVector) = PDiagMat(v, inv.(v))

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -35,6 +35,14 @@ using Test
             @testset "PDSparseMat" begin
                 test_pdmat(PDSparseMat(sparse(M)), M,          cmat_eq=true, verbose=1, t_eig=false)
             end
+            @testset "PDiagMat inv" begin
+                # Test PDiagMat using a StepRangeLen
+                # the inverse of a StepRangeLen is a different type
+                R = StepRangeLen{T}(0.1,0.1,5)
+                vec_PDiagMat = PDiagMat(Vector{T}(R))
+                @test PDiagMat(R) == vec_PDiagMat
+                @test PDiagMat(R,inv.(R)) == vec_PDiagMat
+            end
         end
     end
 


### PR DESCRIPTION
Currently for any `AbstractVector` `v` where `typeof(inv(v))` isn't a subtype of `typeof(v))` creating a `PDiagMat` will fail

For example, if we use a range such a `0.1:0.1:0.5` to construct a `PDiagMat` we get this error:

```julia
julia> using PDMats
[ Info: Precompiling PDMats [90014a1f-27ba-587c-ab20-58faa44d9150]

julia> PDiagMat(0.1:0.1:0.5)
ERROR: MethodError: Cannot `convert` an object of type Vector{Float64} to an object of type StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}
Closest candidates are:
  convert(::Type{T}, ::AbstractRange) where T<:AbstractRange at range.jl:148
  convert(::Type{T}, ::LinearAlgebra.Factorization) where T<:AbstractArray at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/factorization.jl:58
  convert(::Type{T}, ::T) where T<:AbstractArray at abstractarray.jl:14
  ...
Stacktrace:
 [1] PDiagMat{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}(d::Int64, v::StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}, inv_v::Vector{Float64})
   @ PDMats ~/git-repos/open_source/julia_packages/PDMats.jl/src/pdiagmat.jl:9
 [2] PDiagMat(v::StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}, inv_v::Vector{Float64})
   @ PDMats ~/git-repos/open_source/julia_packages/PDMats.jl/src/pdiagmat.jl:15
 [3] PDiagMat(v::StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}})
   @ PDMats ~/git-repos/open_source/julia_packages/PDMats.jl/src/pdiagmat.jl:18
 [4] top-level scope
   @ REPL[2]:1

julia> 
``` 

To fix this I've changed [this function](https://github.com/JuliaStats/PDMats.jl/blob/dfcf96c90ade0ad6052855a3e4b3488b3dbe002a/src/pdiagmat.jl#L13) to create a `PDiagMat` with a Union of the two `AbstractVector` types as the types for the two vectors