### PR TITLE
Improve  `chol_lower` and `chol_upper`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -1,7 +1,14 @@
 # Accessing a.L directly might involve an extra copy();
-# instead, always use the stored Cholesky factor:
-chol_lower(a::Cholesky) = a.uplo === 'L' ? a.L : a.U'
-chol_upper(a::Cholesky) = a.uplo === 'U' ? a.U : a.L'
+# instead, always use the stored Cholesky factor
+# Using `a.factors` instead of `a.L` or `a.U` avoids one
+# additional `LowerTriangular` or `UpperTriangular` wrapper and
+# leads to better performance
+function chol_lower(a::Cholesky)
+    return a.uplo === 'L' ? LowerTriangular(a.factors) : LowerTriangular(a.factors')
+end
+function chol_upper(a::Cholesky)
+    return a.uplo === 'U' ? UpperTriangular(a.factors) : UpperTriangular(a.factors')
+end
 
 # For a dense Matrix, the following allows us to avoid the Adjoint wrapper:
 chol_lower(a::Matrix) = cholesky(Symmetric(a, :L)).L

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -13,8 +13,8 @@ using PDMats: chol_lower, chol_upper
     for uplo in (:L, :U)
         ch = cholesky(Symmetric(C, uplo))
         chol_lower(ch)
-        @test (@allocated chol_lower(ch)) < 25  # allow small overhead for wrapper types
+        @test (@allocated chol_lower(ch)) < 33  # allow small overhead for wrapper types
         chol_upper(ch)
-        @test (@allocated chol_upper(ch)) < 25  # allow small overhead for wrapper types
+        @test (@allocated chol_upper(ch)) < 33  # allow small overhead for wrapper types
     end
 end

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -13,8 +13,8 @@ using PDMats: chol_lower, chol_upper
     for uplo in (:L, :U)
         ch = cholesky(Symmetric(C, uplo))
         chol_lower(ch)
-        @test (@allocated chol_lower(ch)) < 50  # allow small overhead for wrapper types
+        @test (@allocated chol_lower(ch)) < 25  # allow small overhead for wrapper types
         chol_upper(ch)
-        @test (@allocated chol_upper(ch)) < 50  # allow small overhead for wrapper types
+        @test (@allocated chol_upper(ch)) < 25  # allow small overhead for wrapper types
     end
 end


### PR DESCRIPTION
This PR improves `chol_lower` and `chol_upper` by using the field `factors` directly:
```julia
julia> using PDMats, LinearAlgebra, BenchmarkTools

julia> C = cholesky(Symmetric(Matrix(I, 250, 250), :L));

julia> @btime PDMats.chol_lower($C);
  # master: 11.995 ns (1 allocation: 16 bytes)
  # this PR: 8.097 ns (1 allocation: 16 bytes)

julia> @btime PDMats.chol_upper($C);
  # master: 15.072 ns (2 allocations: 32 bytes)
  # this PR: 8.106 ns (1 allocation: 16 bytes)

julia> C = cholesky(Symmetric(Matrix(I, 250, 250), :U));

julia> @btime PDMats.chol_lower($C);
  # master: 15.248 ns (2 allocations: 32 bytes)
  # this PR: 8.116 ns (1 allocation: 16 bytes)

julia> @btime PDMats.chol_upper($C);
  # master: 12.136 ns (1 allocation: 16 bytes)
  # this PR: 8.100 ns (1 allocation: 16 bytes)
```