### PR TITLE
Fix right division and add checks of dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -44,11 +44,12 @@ function pdadd!(r::Matrix, a::Matrix, b::PDMat, c)
     _addscal!(r, a, b.mat, c)
 end
 
-*(a::PDMat{S}, c::T) where {S<:Real, T<:Real} = PDMat(a.mat * c)
-*(a::PDMat, x::AbstractVector{T}) where {T} = a.mat * x
-*(a::PDMat, x::AbstractMatrix{T}) where {T} = a.mat * x
+*(a::PDMat, c::Real) = PDMat(a.mat * c)
+*(a::PDMat, x::AbstractVector) = a.mat * x
+*(a::PDMat, x::AbstractMatrix) = a.mat * x
 \(a::PDMat, x::AbstractVecOrMat) = a.chol \ x
-/(x::AbstractVecOrMat, a::PDMat) = x / a.chol
+# return matrix for 1-element vectors `x`, consistent with LinearAlgebra
+/(x::AbstractVecOrMat, a::PDMat) = reshape(x, Val(2)) / a.chol
 
 ### Algebra
 
@@ -94,21 +95,25 @@ invquad!(r::AbstractArray, a::PDMat, x::StridedMatrix) = colwise_dot!(r, x, a.ma
 ### tri products
 
 function X_A_Xt(a::PDMat, x::StridedMatrix)
-    z = rmul!(copy(x), chol_lower(a.chol))
+    @check_argdims dim(a) == size(x, 2)
+    z = x * chol_lower(a.chol)
     return z * transpose(z)
 end
 
 function Xt_A_X(a::PDMat, x::StridedMatrix)
-    z = lmul!(chol_upper(a.chol), copy(x))
+    @check_argdims dim(a) == size(x, 1)
+    z = chol_upper(a.chol) * x
     return transpose(z) * z
 end
 
 function X_invA_Xt(a::PDMat, x::StridedMatrix)
-    z = rdiv!(copy(x), chol_upper(a.chol))
+    @check_argdims dim(a) == size(x, 2)
+    z = x / chol_upper(a.chol)
     return z * transpose(z)
 end
 
 function Xt_invA_X(a::PDMat, x::StridedMatrix)
-    z = ldiv!(chol_lower(a.chol), copy(x))
+    @check_argdims dim(a) == size(x, 1)
+    z = chol_lower(a.chol) \ x
     return transpose(z) * z
 end

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -43,7 +43,7 @@ function pdadd!(r::Matrix, a::Matrix, b::PDSparseMat, c)
     _addscal!(r, a, b.mat, c)
 end
 
-*(a::PDSparseMat, c::T) where {T<:Real} = PDSparseMat(a.mat * c)
+*(a::PDSparseMat, c::Real) = PDSparseMat(a.mat * c)
 *(a::PDSparseMat, x::StridedVecOrMat) = a.mat * x
 \(a::PDSparseMat{T}, x::StridedVecOrMat{T}) where {T<:Real} = convert(Array{T},a.chol \ convert(Array{Float64},x)) #to avoid limitations in sparse factorization library CHOLMOD, see e.g., julia issue #14076
 /(x::StridedVecOrMat{T}, a::PDSparseMat{T}) where {T<:Real} = convert(Array{T},convert(Array{Float64},x) / a.chol )

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -37,12 +37,25 @@ function pdadd!(r::Matrix, a::Matrix, b::ScalMat, c)
     return r
 end
 
-*(a::ScalMat, c::T) where {T<:Real} = ScalMat(a.dim, a.value * c)
-/(a::ScalMat{T}, c::T) where {T<:Real} = ScalMat(a.dim, a.value / c)
-*(a::ScalMat, x::AbstractVector) = a.value * x
-*(a::ScalMat, x::AbstractMatrix) = a.value * x
-\(a::ScalMat, x::AbstractVecOrMat) = x / a.value
-/(x::AbstractVecOrMat, a::ScalMat) = x / a.value
+*(a::ScalMat, c::Real) = ScalMat(a.dim, a.value * c)
+/(a::ScalMat, c::Real) = ScalMat(a.dim, a.value / c)
+function *(a::ScalMat, x::AbstractVector)
+    @check_argdims dim(a) == length(x)
+    return a.value * x
+end
+function *(a::ScalMat, x::AbstractMatrix)
+    @check_argdims dim(a) == size(x, 1)
+    return a.value * x
+end
+function \(a::ScalMat, x::AbstractVecOrMat)
+    @check_argdims dim(a) == size(x, 1)
+    return x / a.value
+end
+function /(x::AbstractVecOrMat, a::ScalMat)
+    @check_argdims dim(a) == size(x, 2)
+    # return matrix for 1-element vectors `x`, consistent with LinearAlgebra
+    return reshape(x, Val(2)) / a.value
+end
 Base.kron(A::ScalMat, B::ScalMat) = ScalMat( dim(A) * dim(B), A.value * B.value )
 
 ### Algebra

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -83,4 +83,30 @@ using Test
         @test d isa PDiagMat{eltype(v),typeof(v)}
         @test d.diag === v
     end
+
+    @testset "division of vectors (dim = 1)" begin
+        A = rand(1, 1)
+        x = randn(1)
+        y = x / A
+        @assert x / A isa Matrix{Float64}
+        @assert size(y) == (1, 1)
+
+        for M in (PDiagMat(vec(A)), ScalMat(1, first(A)))
+            @test x / M isa Matrix{Float64}
+            @test x / M ≈ y
+        end
+
+        # requires https://github.com/JuliaLang/julia/pull/32594
+        if VERSION >= v"1.3.0-DEV.562"
+            @test x / PDMat(A) isa Matrix{Float64}
+            @test x / PDMat(A) ≈ y
+        end
+
+        # right division not defined for CHOLMOD:
+        # `rdiv!(::Matrix{Float64}, ::SuiteSparse.CHOLMOD.Factor{Float64})` not defined
+        if !HAVE_CHOLMOD
+            @test x / PDSparseMat(sparse(first(A), 1, 1)) isa Matrix{Float64}
+            @test x / PDSparseMat(sparse(first(A), 1, 1)) ≈ y
+        end
+    end
 end


### PR DESCRIPTION
To simplify reviewing and to avoid unrelated changes, I extracted the fixes of right division and additional checks of dimensions from https://github.com/JuliaStats/PDMats.jl/pull/152.

This addresses the issues discussed in https://github.com/JuliaStats/PDMats.jl/pull/131#issuecomment-805893449 and makes the behaviour of `/` consistent with LinearAlgebra. Moreover, the dimension checks prevent incorrect behaviour, e.g., currently the following "works":
```julia
julia> using PDMats

julia> ScalMat(4, 2.0) * ones(3)
3-element Vector{Float64}:
 2.0
 2.0
 2.0

julia> ScalMat(4, 2.0) * ones(3, 2)
3×2 Matrix{Float64}:
 2.0  2.0
 2.0  2.0
 2.0  2.0
```