### PR TITLE
Add support for Symmetric{<:Any,<:Diagonal}

### DIFF
--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -17,6 +17,7 @@ function PDMat(mat::AbstractMatrix,chol::Cholesky{T,S}) where {T,S}
 end
 
 PDMat(mat::AbstractMatrix) = PDMat(mat, cholesky(mat))
+PDMat(mat::Symmetric{<:Any,<:Diagonal}) = PDMat(parent(mat), cholesky(mat))
 PDMat(fac::Cholesky) = PDMat(Matrix(fac), fac)
 
 ### Conversion

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,6 +22,19 @@ function _addscal!(r::Matrix, a::Matrix, b::Union{Matrix, SparseMatrixCSC}, c::R
     end
     return r
 end
+function _addscal!(r::Matrix, a::Matrix, b::Diagonal, c::Real)
+    copyto!(r, a)
+    if c == one(c)
+        for i = diagind(a)
+            @inbounds r[i] += b[i]
+        end
+    else
+        for i = diagind(a)
+            @inbounds r[i] += b[i] * c
+        end
+    end
+    return r
+end
 
 function _adddiag!(a::Union{Matrix, SparseMatrixCSC}, v::Real)
     n = size(a, 1)

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -26,6 +26,11 @@ using Test
                 cholL = Cholesky(Matrix(transpose(cholesky(M).factors)), 'L', 0)
                 test_pdmat(PDMat(cholL), M,                    cmat_eq=true, verbose=1)
             end
+            @testset "PDMat from Symmetric" begin
+                d = Diagonal(M)
+                symdiag = Symmetric(d)
+                test_pdmat(PDMat(symdiag), Matrix(d),          cmat_eq=true, verbose=1)
+            end
             @testset "PDiagMat" begin
                 test_pdmat(PDiagMat(V), Matrix(Diagonal(V)),   cmat_eq=true, verbose=1)
             end


### PR DESCRIPTION
On master, this throws:
```julia
  MethodError: Cannot `convert` an object of type Symmetric{Float64, Diagonal{Float64, Vector{Float64}}} to an object of type Diagonal{Float64, Vector{Float64}}
```