### PR TITLE
Implement matrix square root for PDMats

### DIFF
--- a/src/generics.jl
+++ b/src/generics.jl
@@ -28,6 +28,13 @@ Base.kron(A::AbstractPDMat, B::AbstractPDMat) = PDMat(kron(Matrix(A), Matrix(B))
 LinearAlgebra.isposdef(::AbstractPDMat) = true
 LinearAlgebra.ishermitian(::AbstractPDMat) = true
 
+"""
+    sqrt(A::AbstractPDMat)
+
+Return the matrix square root of `A`: the matrix `X` such that ``XX = A``
+"""
+LinearAlgebra.sqrt(A::AbstractPDMat) = PDMat(sqrt(Matrix(A)))
+
 ## whiten and unwhiten
 whiten!(a::AbstractPDMat, x::StridedVecOrMat) = whiten!(x, a, x)
 unwhiten!(a::AbstractPDMat, x::StridedVecOrMat) = unwhiten!(x, a, x)

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -28,11 +28,7 @@ Base.kron(A::AbstractPDMat, B::AbstractPDMat) = PDMat(kron(Matrix(A), Matrix(B))
 LinearAlgebra.isposdef(::AbstractPDMat) = true
 LinearAlgebra.ishermitian(::AbstractPDMat) = true
 
-"""
-    sqrt(A::AbstractPDMat)
-
-Return the matrix square root of `A`: the matrix `X` such that ``XX = A``
-"""
+# Generic fallback
 LinearAlgebra.sqrt(A::AbstractPDMat) = PDMat(sqrt(Matrix(A)))
 
 ## whiten and unwhiten

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -28,9 +28,6 @@ Base.kron(A::AbstractPDMat, B::AbstractPDMat) = PDMat(kron(Matrix(A), Matrix(B))
 LinearAlgebra.isposdef(::AbstractPDMat) = true
 LinearAlgebra.ishermitian(::AbstractPDMat) = true
 
-# Generic fallback
-LinearAlgebra.sqrt(A::AbstractPDMat) = PDMat(sqrt(Matrix(A)))
-
 ## whiten and unwhiten
 whiten!(a::AbstractPDMat, x::StridedVecOrMat) = whiten!(x, a, x)
 unwhiten!(a::AbstractPDMat, x::StridedVecOrMat) = unwhiten!(x, a, x)

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -68,6 +68,7 @@ function LinearAlgebra.logdet(a::PDiagMat)
 end
 LinearAlgebra.eigmax(a::PDiagMat) = maximum(a.diag)
 LinearAlgebra.eigmin(a::PDiagMat) = minimum(a.diag)
+LinearAlgebra.sqrt(a::PDiagMat) = PDiagMat(map(sqrt, a.diag))
 
 
 ### whiten and unwhiten

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -57,7 +57,7 @@ LinearAlgebra.logdet(a::PDMat) = logdet(a.chol)
 LinearAlgebra.eigmax(a::PDMat) = eigmax(a.mat)
 LinearAlgebra.eigmin(a::PDMat) = eigmin(a.mat)
 Base.kron(A::PDMat, B::PDMat) = PDMat(kron(A.mat, B.mat), Cholesky(kron(A.chol.U, B.chol.U), 'U', A.chol.info))
-LinearAlgebra.sqrt(A::PDMat) = PDMat(sqrt(A.mat))
+LinearAlgebra.sqrt(A::PDMat) = PDMat(sqrt(Hermitian(A.mat)))
 
 ### whiten and unwhiten
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -57,6 +57,7 @@ LinearAlgebra.logdet(a::PDMat) = logdet(a.chol)
 LinearAlgebra.eigmax(a::PDMat) = eigmax(a.mat)
 LinearAlgebra.eigmin(a::PDMat) = eigmin(a.mat)
 Base.kron(A::PDMat, B::PDMat) = PDMat(kron(A.mat, B.mat), Cholesky(kron(A.chol.U, B.chol.U), 'U', A.chol.info))
+LinearAlgebra.sqrt(A::PDMat) = PDMat(sqrt(A.mat))
 
 ### whiten and unwhiten
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -52,7 +52,7 @@ end
 
 Base.inv(a::PDSparseMat{T}) where {T<:Real} = PDMat(inv(a.mat))
 LinearAlgebra.logdet(a::PDSparseMat) = logdet(a.chol)
-LinearAlgebra.sqrt(A::PDSparseMat) = PDSparseMat(sparse(sqrt(Matrix(A))))
+LinearAlgebra.sqrt(A::PDSparseMat) = PDMat(sqrt(Hermitian(Matrix(A))))
 
 ### whiten and unwhiten
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -52,6 +52,7 @@ end
 
 Base.inv(a::PDSparseMat{T}) where {T<:Real} = PDMat(inv(a.mat))
 LinearAlgebra.logdet(a::PDSparseMat) = logdet(a.chol)
+LinearAlgebra.sqrt(A::PDSparseMat) = PDSparseMat(sparse(sqrt(Matrix(A))))
 
 ### whiten and unwhiten
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -64,6 +64,7 @@ Base.inv(a::ScalMat) = ScalMat(a.dim, inv(a.value))
 LinearAlgebra.logdet(a::ScalMat) = a.dim * log(a.value)
 LinearAlgebra.eigmax(a::ScalMat) = a.value
 LinearAlgebra.eigmin(a::ScalMat) = a.value
+LinearAlgebra.sqrt(a::ScalMat) = ScalMat(a.dim, sqrt(a.value))
 
 
 ### whiten and unwhiten

--- a/test/kron.jl
+++ b/test/kron.jl
@@ -2,17 +2,6 @@ using PDMats
 using Test
 using LinearAlgebra: LinearAlgebra
 
-_randPDMat(T, n) = (X = randn(T, n, n); PDMat(X * X' + LinearAlgebra.I))
-_randPDiagMat(T, n) = PDiagMat(rand(T, n))
-_randScalMat(T, n) = ScalMat(n, rand(T))
-
-function _pd_compare(A::AbstractPDMat, B::AbstractPDMat)
-    @test dim(A) == dim(B)
-    @test Matrix(A) ≈ Matrix(B)
-    @test cholesky(A).L ≈ cholesky(B).L
-    @test cholesky(A).U ≈ cholesky(B).U
-end
-
 function _pd_kron_compare(A::AbstractPDMat, B::AbstractPDMat)
     PDAkB_kron = kron(A, B)
     PDAkB_dense = PDMat( kron( Matrix(A), Matrix(B) ) )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 include("testutils.jl")
-tests = ["pdmtypes", "addition", "generics", "kron", "chol", "specialarrays"]
+tests = ["pdmtypes", "addition", "generics", "kron", "chol", "specialarrays", "sqrt"]
 println("Running tests ...")
 
 for t in tests

--- a/test/sqrt.jl
+++ b/test/sqrt.jl
@@ -1,0 +1,44 @@
+using PDMats
+using Test
+using LinearAlgebra: LinearAlgebra
+
+_randPDMat(T, n) = (X = randn(T, n, n); PDMat(X * X' + LinearAlgebra.I))
+_randPDiagMat(T, n) = PDiagMat(rand(T, n))
+_randScalMat(T, n) = ScalMat(n, rand(T))
+_randPDSparseMat(T, n) = (X = T.(sprand(n, 1, 0.5)); PDSparseMat(X * X' + LinearAlgebra.I))
+
+function _pd_compare(A::AbstractPDMat, B::AbstractPDMat)
+    @test dim(A) == dim(B)
+    @test Matrix(A) ≈ Matrix(B)
+    @test cholesky(A).L ≈ cholesky(B).L
+    @test cholesky(A).U ≈ cholesky(B).U
+end
+
+function _pd_sqrt_compare(A::AbstractPDMat)
+    PDAsqrt = sqrt(A)
+    PDAaqrt_dense = PDMat(sqrt(Matrix(A)))
+    _pd_compare(PDAsqrt, PDAaqrt_dense)
+end
+
+function _pdsparse_sqrt_compare(A::AbstractPDMat)
+    # specific method required for testing cholesky of a sparse matrix
+    Asqrt = sqrt(A)
+    Asqrt_dense = PDMat(sqrt(Matrix(A)))
+    @test dim(Asqrt) == dim(Asqrt_dense)
+    @test Matrix(Asqrt) ≈ Matrix(Asqrt_dense)
+    cAsqrt = cholesky(Asqrt)
+    perm = cAsqrt.p  # account for permutation
+    L = sparse(cAsqrt.L)
+    @test Asqrt[perm, perm] ≈ L * L'
+end
+
+n = 10
+
+@testset "Matrix square root" begin
+    for T in [Float32, Float64]
+        _pd_sqrt_compare( _randPDMat(T, n))
+        _pd_sqrt_compare( _randPDiagMat(T, n))
+        _pd_sqrt_compare( _randScalMat(T, n))
+        _pdsparse_sqrt_compare( _randPDSparseMat(T, n))
+    end
+end

--- a/test/sqrt.jl
+++ b/test/sqrt.jl
@@ -6,8 +6,12 @@ _randPDSparseMat(T, n) = (X = T.(sprand(n, 1, 0.5)); PDSparseMat(X * X' + Linear
 
 function _pd_sqrt_compare(A::AbstractPDMat)
     PDAsqrt = sqrt(A)
-    PDAaqrt_dense = PDMat(sqrt(Matrix(A)))
-    _pd_compare(PDAsqrt, PDAaqrt_dense)
+    Asqrt_dense = sqrt(Matrix(A))
+    _pd_compare(PDAsqrt, PDMat(Asqrt_dense))
+    pdtest_cmat(PDAsqrt, Asqrt_dense, false, 0)
+    pdtest_diag(PDAsqrt, Asqrt_dense, false, 0)
+    pdtest_scale(PDAsqrt, Asqrt_dense, 0)
+    return PDAsqrt, Asqrt_dense
 end
 
 n = 10

--- a/test/sqrt.jl
+++ b/test/sqrt.jl
@@ -10,18 +10,6 @@ function _pd_sqrt_compare(A::AbstractPDMat)
     _pd_compare(PDAsqrt, PDAaqrt_dense)
 end
 
-function _pdsparse_sqrt_compare(A::AbstractPDMat)
-    # specific method required for testing cholesky of a sparse matrix
-    Asqrt = sqrt(A)
-    Asqrt_dense = PDMat(sqrt(Matrix(A)))
-    @test dim(Asqrt) == dim(Asqrt_dense)
-    @test Matrix(Asqrt) ≈ Matrix(Asqrt_dense)
-    cAsqrt = cholesky(Asqrt)
-    perm = cAsqrt.p  # account for permutation
-    L = sparse(cAsqrt.L)
-    @test Asqrt[perm, perm] ≈ L * L'
-end
-
 n = 10
 
 @testset "Matrix square root" begin
@@ -29,6 +17,6 @@ n = 10
         _pd_sqrt_compare( _randPDMat(T, n))
         _pd_sqrt_compare( _randPDiagMat(T, n))
         _pd_sqrt_compare( _randScalMat(T, n))
-        _pdsparse_sqrt_compare( _randPDSparseMat(T, n))
+        _pd_sqrt_compare( _randPDSparseMat(T, n))
     end
 end

--- a/test/sqrt.jl
+++ b/test/sqrt.jl
@@ -2,12 +2,9 @@ using PDMats
 using Test
 using LinearAlgebra: LinearAlgebra
 
-_randPDSparseMat(T, n) = (X = T.(sprand(n, 1, 0.5)); PDSparseMat(X * X' + LinearAlgebra.I))
-
 function _pd_sqrt_compare(A::AbstractPDMat)
     PDAsqrt = sqrt(A)
     Asqrt_dense = sqrt(Matrix(A))
-    _pd_compare(PDAsqrt, PDMat(Asqrt_dense))
     pdtest_cmat(PDAsqrt, Asqrt_dense, false, 0)
     pdtest_diag(PDAsqrt, Asqrt_dense, false, 0)
     pdtest_scale(PDAsqrt, Asqrt_dense, 0)

--- a/test/sqrt.jl
+++ b/test/sqrt.jl
@@ -2,17 +2,7 @@ using PDMats
 using Test
 using LinearAlgebra: LinearAlgebra
 
-_randPDMat(T, n) = (X = randn(T, n, n); PDMat(X * X' + LinearAlgebra.I))
-_randPDiagMat(T, n) = PDiagMat(rand(T, n))
-_randScalMat(T, n) = ScalMat(n, rand(T))
 _randPDSparseMat(T, n) = (X = T.(sprand(n, 1, 0.5)); PDSparseMat(X * X' + LinearAlgebra.I))
-
-function _pd_compare(A::AbstractPDMat, B::AbstractPDMat)
-    @test dim(A) == dim(B)
-    @test Matrix(A) ≈ Matrix(B)
-    @test cholesky(A).L ≈ cholesky(B).L
-    @test cholesky(A).U ≈ cholesky(B).U
-end
 
 function _pd_sqrt_compare(A::AbstractPDMat)
     PDAsqrt = sqrt(A)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -326,6 +326,7 @@ end
 _randPDMat(T, n) = (X = randn(T, n, n); PDMat(X * X' + LinearAlgebra.I))
 _randPDiagMat(T, n) = PDiagMat(rand(T, n))
 _randScalMat(T, n) = ScalMat(n, rand(T))
+_randPDSparseMat(T, n) = (X = T.(sprand(n, 1, 0.5)); PDSparseMat(X * X' + LinearAlgebra.I))
 
 function _pd_compare(A::AbstractPDMat, B::AbstractPDMat)
     @test dim(A) == dim(B)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -198,7 +198,7 @@ function pdtest_mul(C::AbstractPDMat, Cmat::Matrix, X::Matrix, verbose::Int)
     end
 
     # Dimension mismatches
-    @test_throws DimensionMismatch C * rand(d + 1) 
+    @test_throws DimensionMismatch C * rand(d + 1)
     @test_throws DimensionMismatch C * rand(d + 1, n)
 end
 
@@ -223,7 +223,7 @@ function pdtest_div(C::AbstractPDMat, Imat::Matrix, X::Matrix, verbose::Int)
 
 
     # Dimension mismatches
-    @test_throws DimensionMismatch C \ rand(d + 1) 
+    @test_throws DimensionMismatch C \ rand(d + 1)
     @test_throws DimensionMismatch C \ rand(d + 1, n)
     if check_rdiv
         @test_throws DimensionMismatch rand(1, d + 1) / C
@@ -318,4 +318,18 @@ function pdtest_whiten(C::AbstractPDMat, Cmat::Matrix, verbose::Int)
     _pdt(verbose, "whiten-unwhiten")
     @test unwhiten(C, whiten(C, Matrix{eltype(C)}(I, d, d))) ≈ Matrix{eltype(C)}(I, d, d)
     @test whiten(C, unwhiten(C, Matrix{eltype(C)}(I, d, d))) ≈ Matrix{eltype(C)}(I, d, d)
+end
+
+
+# testing functions for kron and sqrt
+
+_randPDMat(T, n) = (X = randn(T, n, n); PDMat(X * X' + LinearAlgebra.I))
+_randPDiagMat(T, n) = PDiagMat(rand(T, n))
+_randScalMat(T, n) = ScalMat(n, rand(T))
+
+function _pd_compare(A::AbstractPDMat, B::AbstractPDMat)
+    @test dim(A) == dim(B)
+    @test Matrix(A) ≈ Matrix(B)
+    @test cholesky(A).L ≈ cholesky(B).L
+    @test cholesky(A).U ≈ cholesky(B).U
 end


### PR DESCRIPTION
The matrix square root, [`LinearAlgebra.sqrt()`](https://github.com/JuliaLang/julia/blob/dcc0efe26fd0490bf963be8d50dc6df83b91a868/stdlib/LinearAlgebra/src/dense.jl#L806), is not currently implemented for `PDMats`, i.e., `sqrt(::AbstractPDMat)` throws an error.

This PR implements this by applying `sqrt(Matrix(A))` in the generic case, `sqrt(A.mat)` where possible, plus specific cases for `PDiagMat`, `ScaleMat` and `PDSparseMat`.

Tests also written which check the specific cases return the same result as `sqrt(Matrix(A))`, which I believe is sufficient.