### PR TITLE
Simplify `kron(::PDiagMat, ::PDiagMat)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.12"
+version = "0.11.13"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.11"
+version = "0.11.12"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -57,7 +57,7 @@ function /(x::AbstractVecOrMat, a::PDiagMat)
     # return matrix for 1-element vectors `x`, consistent with LinearAlgebra
     return reshape(x, Val(2)) ./ permutedims(a.diag) # = (a' \ x')'
 end
-Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat( vcat([A.diag[i] * B.diag for i in 1:dim(A)]...) )
+Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat(vec(permutedims(A.diag) .* B.diag))
 
 ### Algebra
 

--- a/test/kron.jl
+++ b/test/kron.jl
@@ -3,7 +3,7 @@ using Test
 using LinearAlgebra: LinearAlgebra
 
 function _pd_kron_compare(A::AbstractPDMat, B::AbstractPDMat)
-    PDAkB_kron = kron(A, B)
+    PDAkB_kron = @inferred kron(A, B)
     PDAkB_dense = PDMat( kron( Matrix(A), Matrix(B) ) )
     _pd_compare(PDAkB_kron, PDAkB_dense)
 end

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -18,6 +18,7 @@ using StaticArrays
         # Diagonal matrix
         D = PDiagMat(@SVector(rand(4)))
         @test D isa PDiagMat{Float64, <:SVector{4, Float64}}
+        @test @inferred(kron(D, D)) isa PDiagMat{Float64, <:SVector{16, Float64}}
 
         x = @SVector rand(4)
         X = @SMatrix rand(10, 4)


### PR DESCRIPTION
This PR simplifies `kron` with `PDiagMat` and also avoids indexing issues (see #163).

## On the master branch

```julia
julia> using PDMats, BenchmarkTools

julia> A = PDiagMat(rand(100));

julia> B = PDiagMat(rand(100));

julia> @btime kron($A, $B);
  13.395 μs (103 allocations: 166.55 KiB)
```

## This PR

```julia
julia> using PDMats, BenchmarkTools

julia> A = PDiagMat(rand(100));

julia> B = PDiagMat(rand(100));

julia> @btime kron($A, $B);
  4.625 μs (6 allocations: 78.34 KiB)
```

Accidentally, I had pushed the changes directly to the master branch (already reverted it).

Edit: Additionally, the PR fixes some type inference issues:

## On the master branch

```julia
julia> using PDMats, StaticArrays, Test

julia> typeof(kron(PDiagMat(@SVector([0.1, 0.2, 0.5])), PDiagMat(@SVector([0.2, 0.4, 1.2]))))
PDiagMat{Float64, SVector{9, Float64}}

julia> @inferred(kron(PDiagMat(@SVector([0.1, 0.2, 0.5])), PDiagMat(@SVector([0.2, 0.4, 1.2]))));
ERROR: return type PDiagMat{Float64, SVector{9, Float64}} does not match inferred return type PDiagMat
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] top-level scope
   @ REPL[9]:1
```

## With this PR

```julia
julia> using PDMats, StaticArrays, Test

julia> typeof(kron(PDiagMat(@SVector([0.1, 0.2, 0.5])), PDiagMat(@SVector([0.2, 0.4, 1.2]))))
PDiagMat{Float64, SVector{9, Float64}}

julia> @inferred(kron(PDiagMat(@SVector([0.1, 0.2, 0.5])), PDiagMat(@SVector([0.2, 0.4, 1.2]))));
```