### PR TITLE
Improve constructor `PDMat(::Cholesky)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.11"
+version = "0.11.12"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -17,7 +17,7 @@ function PDMat(mat::AbstractMatrix,chol::Cholesky{T,S}) where {T,S}
 end
 
 PDMat(mat::AbstractMatrix) = PDMat(mat, cholesky(mat))
-PDMat(fac::Cholesky) = PDMat(Matrix(fac), fac)
+PDMat(fac::Cholesky) = PDMat(AbstractMatrix(fac), fac)
 
 ### Conversion
 Base.convert(::Type{PDMat{T}},         a::PDMat) where {T<:Real} = PDMat(convert(AbstractArray{T}, a.mat))

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -111,10 +111,14 @@ using Test
     end
 
     @testset "PDMat from Cholesky decomposition of diagonal matrix (#137)" begin
-        x = rand(10, 10)
-        A = Diagonal(x' * x)
-        M = PDMat(cholesky(A))
-        @test M isa PDMat{Float64, typeof(A)}
-        @test Matrix(M) ≈ A
+        # U'*U where U isa UpperTriangular etc.
+        # requires https://github.com/JuliaLang/julia/pull/33334
+        if VERSION >= v"1.4.0-DEV.286"
+            x = rand(10, 10)
+            A = Diagonal(x' * x)
+            M = PDMat(cholesky(A))
+            @test M isa PDMat{Float64, typeof(A)}
+            @test Matrix(M) ≈ A
+        end
     end
 end

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -109,4 +109,12 @@ using Test
             @test x / PDSparseMat(sparse(first(A), 1, 1)) ≈ y
         end
     end
+
+    @testset "PDMat from Cholesky decomposition of diagonal matrix (#137)" begin
+        x = rand(10, 10)
+        A = Diagonal(x' * x)
+        M = PDMat(cholesky(A))
+        @test M isa PDMat{Float64, typeof(A)}
+        @test Matrix(M) ≈ A
+    end
 end

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -8,6 +8,12 @@ using StaticArrays
         PDS = PDMat(S)
         @test PDS isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
         @test isbits(PDS)
+        C = cholesky(S)
+        PDC = PDMat(C)
+        @test typeof(PDC) === typeof(PDS)
+        @test Matrix(PDC) ≈ Matrix(PDS)
+        @test PDMat(S, C) === PDS
+        @test @allocated(PDMat(S)) == @allocated(PDMat(C)) == @allocated(PDMat(S, C))
 
         # Diagonal matrix
         D = PDiagMat(@SVector(rand(4)))


### PR DESCRIPTION
This PR fixes #155. This PR fixes #137.

## On the master branch

```julia
julia> using PDMats, StaticArrays, BenchmarkTools, LinearAlgebra

julia> A = SMatrix{3,3}(rand(3, 3));

julia> B = A * A' +  I;

julia> @btime PDMat($(cholesky(B)));
  45.653 ns (1 allocation: 128 bytes)
```

## With this PR

```julia
julia> using PDMats, StaticArrays, BenchmarkTools, LinearAlgebra

julia> A = SMatrix{3,3}(rand(3, 3));

julia> B = A * A' +  I;

julia> @btime PDMat($(cholesky(B)));
  9.706 ns (0 allocations: 0 bytes)
```