### PR TITLE
dim(a) -> LinearAlgebra.checksquare(a)

### DIFF
--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -71,12 +71,12 @@ LinearAlgebra.sqrt(a::ScalMat) = ScalMat(a.dim, sqrt(a.value))
 ### whiten and unwhiten
 
 function whiten!(r::AbstractVecOrMat, a::ScalMat, x::AbstractVecOrMat)
-    @check_argdims dim(a) == size(x, 1)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
     _ldiv!(r, sqrt(a.value), x)
 end
 
 function unwhiten!(r::AbstractVecOrMat, a::ScalMat, x::AbstractVecOrMat)
-    @check_argdims dim(a) == size(x, 1)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
     mul!(r, x, sqrt(a.value))
 end
 
@@ -93,21 +93,21 @@ invquad!(r::AbstractArray, a::ScalMat, x::AbstractMatrix) = colwise_sumsqinv!(r,
 ### tri products
 
 function X_A_Xt(a::ScalMat, x::AbstractMatrix)
-    @check_argdims dim(a) == size(x, 2)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
     lmul!(a.value, x * transpose(x))
 end
 
 function Xt_A_X(a::ScalMat, x::AbstractMatrix)
-    @check_argdims dim(a) == size(x, 1)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
     lmul!(a.value, transpose(x) * x)
 end
 
 function X_invA_Xt(a::ScalMat, x::AbstractMatrix)
-    @check_argdims dim(a) == size(x, 2)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
     _rdiv!(x * transpose(x), a.value)
 end
 
 function Xt_invA_X(a::ScalMat, x::AbstractMatrix)
-    @check_argdims dim(a) == size(x, 1)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
     _rdiv!(transpose(x) * x, a.value)
 end


### PR DESCRIPTION
It seems one use of `dim` was not removed from the package when it was deprecated.