### PR TITLE
Improve `convert` definitions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.18"
+version = "0.11.19"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -4,6 +4,10 @@
 AbstractPDMat(A::AbstractPDMat) = A
 AbstractPDMat(A::AbstractMatrix) = PDMat(A)
 
+## convert
+Base.convert(::Type{AbstractMatrix{T}}, a::AbstractPDMat) where {T<:Real} = convert(AbstractPDMat{T}, a) 
+Base.convert(::Type{AbstractArray{T}}, a::AbstractPDMat) where {T<:Real} = convert(AbstractMatrix{T}, a)
+
 ## arithmetics
 
 pdadd!(r::Matrix, a::Matrix, b::AbstractPDMat{T}) where {T<:Real} = pdadd!(r, a, b, one(T))

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -13,8 +13,12 @@ AbstractPDMat(A::Symmetric{<:Real,<:Diagonal{<:Real}}) = PDiagMat(A.data.diag)
 AbstractPDMat(A::Hermitian{<:Real,<:Diagonal{<:Real}}) = PDiagMat(A.data.diag)
 
 ### Conversion
-Base.convert(::Type{PDiagMat{T}},      a::PDiagMat) where {T<:Real} = PDiagMat(convert(AbstractArray{T}, a.diag))
-Base.convert(::Type{AbstractArray{T}}, a::PDiagMat) where {T<:Real} = convert(PDiagMat{T}, a)
+Base.convert(::Type{PDiagMat{T}}, a::PDiagMat{T}) where {T<:Real} = a
+function Base.convert(::Type{PDiagMat{T}}, a::PDiagMat) where {T<:Real}
+    diag = convert(AbstractVector{T}, a.diag)
+    return PDiagMat{T,typeof(diag)}(a.dim, diag)
+end
+Base.convert(::Type{AbstractPDMat{T}}, a::PDiagMat) where {T<:Real} = convert(PDiagMat{T}, a)
 
 ### Basics
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -22,9 +22,14 @@ PDMat(fac::Cholesky) = PDMat(AbstractMatrix(fac), fac)
 AbstractPDMat(A::Cholesky) = PDMat(A)
 
 ### Conversion
-Base.convert(::Type{PDMat{T}},         a::PDMat) where {T<:Real} = PDMat(convert(AbstractArray{T}, a.mat))
-Base.convert(::Type{AbstractArray{T}}, a::PDMat) where {T<:Real} = convert(PDMat{T}, a)
-Base.convert(::Type{AbstractArray{T}}, a::PDMat{T}) where {T<:Real} = a
+Base.convert(::Type{PDMat{T}}, a::PDMat{T}) where {T<:Real} = a
+function Base.convert(::Type{PDMat{T}}, a::PDMat) where {T<:Real}
+    chol = convert(Cholesky{T}, a.chol)
+    S = typeof(chol.factors)
+    mat = convert(S, a.mat)
+    return PDMat{T,S}(size(mat, 1), mat, chol)
+end
+Base.convert(::Type{AbstractPDMat{T}}, a::PDMat) where {T<:Real} = convert(PDMat{T}, a)
 
 ### Basics
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -27,6 +27,8 @@ AbstractPDMat(A::CholTypeSparse) = PDSparseMat(A)
 Base.convert(::Type{PDSparseMat{T}}, a::PDSparseMat{T}) where {T<:Real} = a
 function Base.convert(::Type{PDSparseMat{T}}, a::PDSparseMat) where {T<:Real}
     # CholTypeSparse only supports Float64 and ComplexF64 type parameters!
+    # So there is no point in recomputing `cholesky(mat)` and we just reuse
+    # the existing Cholesky factorization
     mat = convert(AbstractMatrix{T}, a.mat)
     return PDSparseMat{T,typeof(mat)}(a.dim, mat, a.chol)
 end

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -24,7 +24,13 @@ AbstractPDMat(A::SparseMatrixCSC) = PDSparseMat(A)
 AbstractPDMat(A::CholTypeSparse) = PDSparseMat(A)
 
 ### Conversion
-Base.convert(::Type{PDSparseMat{T}}, a::PDSparseMat) where {T<:Real} = PDSparseMat(convert(SparseMatrixCSC{T}, a.mat))
+Base.convert(::Type{PDSparseMat{T}}, a::PDSparseMat{T}) where {T<:Real} = a
+function Base.convert(::Type{PDSparseMat{T}}, a::PDSparseMat) where {T<:Real}
+    # CholTypeSparse only supports Float64 and ComplexF64 type parameters!
+    mat = convert(AbstractMatrix{T}, a.mat)
+    return PDSparseMat{T,typeof(mat)}(a.dim, mat, a.chol)
+end
+Base.convert(::Type{AbstractPDMat{T}}, a::PDSparseMat) where {T<:Real} = convert(PDSparseMat{T}, a)
 
 ### Basics
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -7,8 +7,9 @@ struct ScalMat{T<:Real} <: AbstractPDMat{T}
 end
 
 ### Conversion
+Base.convert(::Type{ScalMat{T}}, a::ScalMat{T}) where {T<:Real} = a
 Base.convert(::Type{ScalMat{T}}, a::ScalMat) where {T<:Real} = ScalMat(a.dim, T(a.value))
-Base.convert(::Type{AbstractArray{T}}, a::ScalMat) where {T<:Real} = convert(ScalMat{T}, a)
+Base.convert(::Type{AbstractPDMat{T}}, a::ScalMat) where {T<:Real} = convert(ScalMat{T}, a)
 
 ### Basics
 

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -45,23 +45,49 @@ using Test
     end
 
     @testset "float type conversions" begin
-        m = Matrix{Float32}(I, 2, 2)
-        @test convert(PDMat{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
-        @test convert(AbstractArray{Float64}, PDMat(m)).mat == PDMat(convert(Array{Float64}, m)).mat
-        m = ones(Float32,2)
-        @test convert(PDiagMat{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
-        @test convert(AbstractArray{Float64}, PDiagMat(m)).diag == PDiagMat(convert(Array{Float64}, m)).diag
-        x = one(Float32); d = 4
-        @test convert(ScalMat{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
-        @test convert(AbstractArray{Float64}, ScalMat(d, x)).value == ScalMat(d, convert(Float64, x)).value
-        s = SparseMatrixCSC{Float32}(I, 2, 2)
-        @test convert(PDSparseMat{Float64}, PDSparseMat(s)).mat == PDSparseMat(convert(SparseMatrixCSC{Float64}, s)).mat
-    end
+        for T in (Float32, Float64), S in (Float32, Float64)
+            A = PDMat(Matrix{T}(I, 2, 2))
+            for R in (AbstractArray{S}, AbstractMatrix{S}, AbstractPDMat{S}, PDMat{S})
+                B = @inferred(convert(R, A))
+                @test B isa PDMat{S}
+                @test B == A
+                @test (B === A) === (S === T)
+                @test (B.mat === A.mat) === (S === T)
+                @test (B.chol === A.chol) === (S === T)
+            end
 
-    @testset "no-op conversion with correct eltype (#101)" begin
-        X = PDMat((Y->Y'Y)(randn(Float32, 4, 4)))
-        @test convert(AbstractArray{Float32}, X) === X
-        @test convert(AbstractArray{Float64}, X) !== X
+            A = PDiagMat(ones(T, 2))
+            for R in (AbstractArray{S}, AbstractMatrix{S}, AbstractPDMat{S}, PDiagMat{S})
+                B = @inferred(convert(R, A))
+                @test B isa PDiagMat{S}
+                @test B == A
+                @test (B === A) === (S === T)
+                @test (B.diag === A.diag) === (S === T)
+            end
+
+            A = ScalMat(4, T(1))
+            for R in (AbstractArray{S}, AbstractMatrix{S}, AbstractPDMat{S}, ScalMat{S})
+                B = @inferred(convert(R, A))
+                @test B isa ScalMat{S}
+                @test B == A
+                @test (B === A) === (S === T)
+                @test (B.value === A.value) === (S === T)
+            end
+
+            if HAVE_CHOLMOD
+                A = PDSparseMat(SparseMatrixCSC{T}(I, 2, 2))
+                for R in (AbstractArray{S}, AbstractMatrix{S}, AbstractPDMat{S}, PDSparseMat{S})
+                    B = @inferred(convert(R, A))
+                    @test B isa PDSparseMat{S}
+                    @test B == A
+                    @test (B === A) === (S === T)
+                    @test (B.mat === A.mat) === (S === T)
+                    # CholMOD only supports Float64 and ComplexF64 type parameters!
+                    # Hence the Cholesky factorization is reused
+                    @test B.chol === A.chol
+                end
+            end
+        end
     end
 
     @testset "type stability of whiten! and unwhiten!" begin


### PR DESCRIPTION
Adds missing `convert` definitions and improves efficiency of existing ones. For instance, the PR fixes unnecessary calls of `cholesky` when converting `PDMat`s.

Fixes https://github.com/JuliaStats/Distributions.jl/issues/1781.

Edit: #180 should be merged first.