### PR TITLE
Fix `/` on Julia >= 1.9 and broken tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.17"
+version = "0.11.18"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -58,8 +58,12 @@ function \(a::PDiagMat, x::AbstractVecOrMat)
 end
 function /(x::AbstractVecOrMat, a::PDiagMat)
     @check_argdims a.dim == size(x, 2)
-    # return matrix for 1-element vectors `x`, consistent with LinearAlgebra
-    return reshape(x, Val(2)) ./ permutedims(a.diag) # = (a' \ x')'
+    if VERSION < v"1.9-"
+        # return matrix for 1-element vectors `x`, consistent with LinearAlgebra < 1.9
+        return reshape(x, Val(2)) ./ permutedims(a.diag) # = (a' \ x')'
+    else
+        return x ./ (x isa AbstractVector ? a.diag : a.diag')
+    end
 end
 Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat(vec(permutedims(A.diag) .* B.diag))
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -49,8 +49,19 @@ end
 *(a::PDMat, x::AbstractVector) = a.mat * x
 *(a::PDMat, x::AbstractMatrix) = a.mat * x
 \(a::PDMat, x::AbstractVecOrMat) = a.chol \ x
-# return matrix for 1-element vectors `x`, consistent with LinearAlgebra
-/(x::AbstractVecOrMat, a::PDMat) = reshape(x, Val(2)) / a.chol
+function /(x::AbstractVecOrMat, a::PDMat)
+    # /(::AbstractVector, ::Cholesky) is not defined
+    if VERSION < v"1.9-"
+        # return matrix for 1-element vectors `x`, consistent with LinearAlgebra
+        return reshape(x, Val(2)) / a.chol
+    else
+        if x isa AbstractVector
+            return vec(reshape(x, Val(2)) / a.chol)
+        else
+            return x / a.chol
+        end
+    end
+end
 
 ### Algebra
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -53,8 +53,12 @@ function \(a::ScalMat, x::AbstractVecOrMat)
 end
 function /(x::AbstractVecOrMat, a::ScalMat)
     @check_argdims a.dim == size(x, 2)
-    # return matrix for 1-element vectors `x`, consistent with LinearAlgebra
-    return reshape(x, Val(2)) / a.value
+    if VERSION < v"1.9-"
+        # return matrix for 1-element vectors `x`, consistent with LinearAlgebra < 1.9
+        return reshape(x, Val(2)) / a.value
+    else
+        return x / a.value
+    end
 end
 Base.kron(A::ScalMat, B::ScalMat) = ScalMat(A.dim * B.dim, A.value * B.value )
 

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -88,25 +88,29 @@ using Test
         A = rand(1, 1)
         x = randn(1)
         y = x / A
-        @assert x / A isa Matrix{Float64}
-        @assert size(y) == (1, 1)
 
         for M in (PDiagMat(vec(A)), ScalMat(1, first(A)))
-            @test x / M isa Matrix{Float64}
-            @test x / M ≈ y
+            z = x / M
+            @test typeof(z) === typeof(y)
+            @test size(z) == size(y)
+            @test z ≈ y
         end
 
         # requires https://github.com/JuliaLang/julia/pull/32594
         if VERSION >= v"1.3.0-DEV.562"
-            @test x / PDMat(A) isa Matrix{Float64}
-            @test x / PDMat(A) ≈ y
+            z = x / PDMat(A)
+            @test typeof(z) === typeof(y)
+            @test size(z) == size(y)
+            @test z ≈ y
         end
 
         # right division not defined for CHOLMOD:
         # `rdiv!(::Matrix{Float64}, ::SuiteSparse.CHOLMOD.Factor{Float64})` not defined
         if !HAVE_CHOLMOD
-            @test x / PDSparseMat(sparse(first(A), 1, 1)) isa Matrix{Float64}
-            @test x / PDSparseMat(sparse(first(A), 1, 1)) ≈ y
+            z = x / PDSparseMat(sparse(first(A), 1, 1)) 
+            @test typeof(z) === typeof(y)
+            @test size(z) == size(y)
+            @test z ≈ y
         end
     end
 

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -63,17 +63,17 @@ using StaticArrays
         x = rand(5)
         X = rand(2, 5)
         Y = rand(5, 2)
-        @test P * x ≈ A * x
-        @test P * Y ≈ A * Y
+        @test P * x ≈ x
+        @test P * Y ≈ Y
         # Right division with Cholesky requires https://github.com/JuliaLang/julia/pull/32594
         if VERSION >= v"1.3.0-DEV.562"
-            @test X / P ≈ X / A
+            @test X / P ≈ X
         end
-        @test P \ x ≈ A \ x
-        @test P \ Y ≈ A \ Y
-        @test X_A_Xt(P, X) ≈ X * A * X'
-        @test X_invA_Xt(P, X) ≈ X * (A \ X')
-        @test Xt_A_X(P, Y) ≈ Y' * A * Y
-        @test Xt_invA_X(P, Y) ≈ Y' * (A \ Y)
+        @test P \ x ≈ x
+        @test P \ Y ≈ Y
+        @test X_A_Xt(P, X) ≈ X * X'
+        @test X_invA_Xt(P, X) ≈ X * X'
+        @test Xt_A_X(P, Y) ≈ Y' * Y
+        @test Xt_invA_X(P, Y) ≈ Y' * Y
     end
 end


### PR DESCRIPTION
As the title says, this PR fixes tests on all Julia versions.

The main problem on the master branch is that the return type of `/(::AbstractVector, ::AbstractPDMat)` is not consistent anymore with the behaviour in LinearAlgebra >= 1.9. I was not able to track down the exact commit where this behaviour changed but since the first alpha release of 1.9 LinearAlgebra returns a vector in these cases whereas in Julia <= 1.8.5 a matrix was returned.

The second problem were the BandedMatrices tests; they were failing due to some upstream problems (only the computations of the reference values were affected it seems) but this could be fixed by simplifying the calculation of the ground truth values.