### PR TITLE
Support StaticArrays in X(t)_(inv)A_X(t) with ScalMat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.19"
+version = "0.11.20"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -99,20 +99,20 @@ invquad!(r::AbstractArray, a::ScalMat, x::AbstractMatrix) = colwise_sumsqinv!(r,
 
 function X_A_Xt(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
-    lmul!(a.value, x * transpose(x))
+    a.value * (x * transpose(x))
 end
 
 function Xt_A_X(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
-    lmul!(a.value, transpose(x) * x)
+    a.value * (transpose(x) * x)
 end
 
 function X_invA_Xt(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
-    _rdiv!(x * transpose(x), a.value)
+    (x * transpose(x)) / a.value
 end
 
 function Xt_invA_X(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
-    _rdiv!(transpose(x) * x, a.value)
+    (transpose(x) * x) / a.value
 end

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -116,3 +116,24 @@ function Xt_invA_X(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
     (transpose(x) * x) / a.value
 end
+
+# Specializations for `x::Matrix` with reduced allocations
+function X_A_Xt(a::ScalMat, x::Matrix)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
+    lmul!(a.value, x * transpose(x))
+end
+
+function Xt_A_X(a::ScalMat, x::Matrix)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
+    lmul!(a.value, transpose(x) * x)
+end
+
+function X_invA_Xt(a::ScalMat, x::Matrix)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
+    _rdiv!(x * transpose(x), a.value)
+end
+
+function Xt_invA_X(a::ScalMat, x::Matrix)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
+    _rdiv!(transpose(x) * x, a.value)
+end

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -20,11 +20,14 @@ using StaticArrays
         @test D isa PDiagMat{Float64, <:SVector{4, Float64}}
         @test @inferred(kron(D, D)) isa PDiagMat{Float64, <:SVector{16, Float64}}
 
+        # Scaled identity matrix
+        E = ScalMat(4, 1.2)
+
         x = @SVector rand(4)
         X = @SMatrix rand(10, 4)
         Y = @SMatrix rand(4, 10)
 
-        for A in (PDS, D)
+        for A in (PDS, D, E)
             @test A * x isa SVector{4, Float64}
             @test A * x ≈ Matrix(A) * Vector(x)
 


### PR DESCRIPTION
Currently, `ScalMat` does not support `X_A_Xt` etc. with static arrays. For instance, running the tests in this PR on the master branch yields
```julia
StaticArrays: Error During Test at REPL[10]:42
  Test threw exception
  Expression: X_A_Xt(A, X) isa SMatrix{10, 10, Float64}
  setindex!(::SMatrix{10, 10, Float64, 100}, value, ::Int) is not defined.
   Hint: Use `MArray` or `SizedArray` to create a mutable static array
...
StaticArrays: Error During Test at REPL[10]:43
  Test threw exception
  Expression: X_A_Xt(A, X) ≈ Matrix(X) * Matrix(A) * (Matrix(X))'
  setindex!(::SMatrix{10, 10, Float64, 100}, value, ::Int) is not defined.
   Hint: Use `MArray` or `SizedArray` to create a mutable static array
...
StaticArrays: Error During Test at REPL[10]:45
  Test threw exception
  Expression: X_invA_Xt(A, X) isa SMatrix{10, 10, Float64}
  setindex!(::SMatrix{10, 10, Float64, 100}, value, ::Int) is not defined.
   Hint: Use `MArray` or `SizedArray` to create a mutable static array
...
StaticArrays: Error During Test at REPL[10]:46
  Test threw exception
  Expression: X_invA_Xt(A, X) ≈ Matrix(X) * (Matrix(A) \ (Matrix(X))')
  setindex!(::SMatrix{10, 10, Float64, 100}, value, ::Int) is not defined.
   Hint: Use `MArray` or `SizedArray` to create a mutable static array
...
StaticArrays: Error During Test at REPL[10]:48
  Test threw exception
  Expression: Xt_A_X(A, Y) isa SMatrix{10, 10, Float64}
  setindex!(::SMatrix{10, 10, Float64, 100}, value, ::Int) is not defined.
   Hint: Use `MArray` or `SizedArray` to create a mutable static array
...
StaticArrays: Error During Test at REPL[10]:49
  Test threw exception
  Expression: Xt_A_X(A, Y) ≈ (Matrix(Y))' * Matrix(A) * Matrix(Y)
  setindex!(::SMatrix{10, 10, Float64, 100}, value, ::Int) is not defined.
   Hint: Use `MArray` or `SizedArray` to create a mutable static array
...
StaticArrays: Error During Test at REPL[10]:51
  Test threw exception
  Expression: Xt_invA_X(A, Y) isa SMatrix{10, 10, Float64}
  setindex!(::SMatrix{10, 10, Float64, 100}, value, ::Int) is not defined.
   Hint: Use `MArray` or `SizedArray` to create a mutable static array
...
StaticArrays: Error During Test at REPL[10]:52
  Test threw exception
  Expression: Xt_invA_X(A, Y) ≈ (Matrix(Y))' * (Matrix(A) \ Matrix(Y))
  setindex!(::SMatrix{10, 10, Float64, 100}, value, ::Int) is not defined.
   Hint: Use `MArray` or `SizedArray` to create a mutable static array
...
Test Summary: | Pass  Error  Total  Time
StaticArrays  |   54      8     62  4.6s
```

The PR fixes this issue by changing the implementation to a non-mutating alternative, as done already e.g. for `PDiagMat`.

The disadvantage (also with the existing code for other psd matrix types) is that this leads to additional allocations when working with e.g. `Array`. I wonder if generally the non-mutating implementation should be the default (since it works with any matrix type) and additionally possibly internally mutating code for `Array` should be added (since it avoids allocations and this particular matrix type is so common).
