### PR TITLE
Simplify `cholesky` for `ScalMat` and `PDiagMat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.19"
+version = "0.11.20"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -25,7 +25,7 @@ Base.convert(::Type{AbstractPDMat{T}}, a::PDiagMat) where {T<:Real} = convert(PD
 Base.size(a::PDiagMat) = (a.dim, a.dim)
 Base.Matrix(a::PDiagMat) = Matrix(Diagonal(a.diag))
 LinearAlgebra.diag(a::PDiagMat) = copy(a.diag)
-LinearAlgebra.cholesky(a::PDiagMat) = cholesky(Diagonal(a.diag))
+LinearAlgebra.cholesky(a::PDiagMat) = Cholesky(Diagonal(map(sqrt, a.diag)), 'U', 0)
 
 ### Inheriting from AbstractMatrix
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -16,7 +16,7 @@ Base.convert(::Type{AbstractPDMat{T}}, a::ScalMat) where {T<:Real} = convert(Sca
 Base.size(a::ScalMat) = (a.dim, a.dim)
 Base.Matrix(a::ScalMat) = Matrix(Diagonal(fill(a.value, a.dim)))
 LinearAlgebra.diag(a::ScalMat) = fill(a.value, a.dim)
-LinearAlgebra.cholesky(a::ScalMat) = cholesky(Diagonal(fill(a.value, a.dim)))
+LinearAlgebra.cholesky(a::ScalMat) = Cholesky(Diagonal(fill(sqrt(a.value), a.dim)), 'U', 0)
 
 ### Inheriting from AbstractMatrix
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -130,7 +130,9 @@ function pdtest_cholesky(C::Union{PDMat, PDiagMat, ScalMat}, Cmat::Matrix, cmat_
     # regression test: https://github.com/JuliaStats/PDMats.jl/pull/182
     if C isa Union{PDiagMat, ScalMat}
         size_of_sqrt_diag = C.dim * sizeof(float(eltype(C)))
-        @test (@allocated cholesky(C)) <= 1.05 * size_of_sqrt_diag # allow some overhead
+        # allow some overhead
+        max_allocations = max(1.05 * size_of_sqrt_diag, size_of_sqrt_diag + 96)
+        @test (@allocated cholesky(C)) <= max_allocations
     end
 end
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -130,8 +130,8 @@ function pdtest_cholesky(C::Union{PDMat, PDiagMat, ScalMat}, Cmat::Matrix, cmat_
     # regression test: https://github.com/JuliaStats/PDMats.jl/pull/182
     if C isa Union{PDiagMat, ScalMat}
         size_of_sqrt_diag = C.dim * sizeof(float(eltype(C)))
-        # allow some overhead
-        max_allocations = max(1.05 * size_of_sqrt_diag, size_of_sqrt_diag + 96)
+        # allow some overhead for wrapper types
+        max_allocations = max(1.05 * size_of_sqrt_diag, 128 + size_of_sqrt_diag)
         @test (@allocated cholesky(C)) <= max_allocations
     end
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -120,12 +120,17 @@ function pdtest_diag(C, Cmat::Matrix, cmat_eq::Bool, verbose::Int)
     end
 end
 
-function pdtest_cholesky(C::Union{PDMat, PDiagMat}, Cmat::Matrix, cmat_eq::Bool, verbose::Int)
+function pdtest_cholesky(C::Union{PDMat, PDiagMat, ScalMat}, Cmat::Matrix, cmat_eq::Bool, verbose::Int)
     _pdt(verbose, "cholesky")
     if cmat_eq
         @test cholesky(C).U == cholesky(Cmat).U
     else
         @test cholesky(C).U ≈ cholesky(Cmat).U
+    end
+    # regression test: https://github.com/JuliaStats/PDMats.jl/pull/182
+    if C isa Union{PDiagMat, ScalMat}
+        size_of_sqrt_diag = C.dim * sizeof(float(eltype(C)))
+        @test (@allocated cholesky(C)) <= 1.05 * size_of_sqrt_diag # allow some overhead
     end
 end
 


### PR DESCRIPTION
We don't have to go through `cholesky(::Diagonal)` in LinearAlgebra (e.g. https://github.com/JuliaLang/julia/blob/28d9f730c1927297fc0cfc415c842968aa1a3a71/stdlib/LinearAlgebra/src/diagonal.jl#L868) when computing `cholesky(::ScalMat)` or `cholesky(::PDiagMat)` but we can construct the `Cholesky` object directly without any intermediate steps.

This improves performance significantly:

### master

```julia
julia> using PDMats, BenchmarkTools, LinearAlgebra

julia> A = ScalMat(10, 3.2);

julia> @btime cholesky($A);
  47.733 ns (2 allocations: 288 bytes)

julia> A = ScalMat(100, 3.2);

julia> @btime cholesky($A);
  160.778 ns (2 allocations: 1.75 KiB)

julia> A = ScalMat(1_000, 3.2);

julia> @btime cholesky($A);
  1.458 μs (2 allocations: 15.88 KiB)

julia> A = PDiagMat(fill(3.2, 10));

julia> @btime cholesky($A);
  27.261 ns (1 allocation: 144 bytes)

julia> A = PDiagMat(fill(3.2, 100));

julia> @btime cholesky($A);
  116.997 ns (1 allocation: 896 bytes)

julia> A = PDiagMat(fill(3.2, 1_000));

julia> @btime cholesky($A);
  1.250 μs (1 allocation: 7.94 KiB)
```

Note also that `cholesky(::PDiagMat)` is faster than `cholesky(::ScalMat)` due to the reduced number of allocations - the only difference between both code paths is that for the `ScalMat` the diagonal `fill(a.value, a.dim)` is only constructed inside of the `cholesky` call whereas it already exists for the `PDiagMat`.

### This PR

```julia
julia> using PDMats, BenchmarkTools, LinearAlgebra

julia> A = ScalMat(10, 3.2);

julia> @btime cholesky($A);
  16.450 ns (1 allocation: 144 bytes)

julia> A = ScalMat(100, 3.2);

julia> @btime cholesky($A);
  29.816 ns (1 allocation: 896 bytes)

julia> A = ScalMat(1_000, 3.2);

julia> @btime cholesky($A);
  164.808 ns (1 allocation: 7.94 KiB)

julia> A = PDiagMat(fill(3.2, 10));

julia> @btime cholesky($A);
  20.227 ns (1 allocation: 144 bytes)

julia> A = PDiagMat(fill(3.2, 100));

julia> @btime cholesky($A);
  74.040 ns (1 allocation: 896 bytes)

julia> A = PDiagMat(fill(3.2, 1_000));

julia> @btime cholesky($A);
  691.478 ns (1 allocation: 7.94 KiB)
```

Note that with this change, as expected, `cholesky(::ScalMat)` will be faster than the corresponding `cholesky(::PDiagMat)` since it only requires a single `sqrt` computation.