### PR TITLE
Support `(un)whiten` and `(inv)quad` with static arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.19"
+version = "0.11.20"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -100,11 +100,6 @@ function quad(a::PDSparseMat, x::AbstractVecOrMat)
     z = sparse(chol_lower(cholesky(a)))' * x
     return x isa AbstractVector ? sum(abs2, z) : vec(sum(abs2, z; dims = 1))
 end
-function invquad(a::PDSparseMat, x::AbstractVecOrMat)
-    @check_argdims a.dim == size(x, 1)
-    z = sparse(chol_lower(cholesky(a))) \ x
-    return x isa AbstractVector ? sum(abs2, z) : vec(sum(abs2, z; dims = 1))
-end
 
 function quad!(r::AbstractArray, a::PDSparseMat, x::AbstractMatrix)
     @check_argdims eachindex(r) == axes(x, 2)
@@ -112,6 +107,12 @@ function quad!(r::AbstractArray, a::PDSparseMat, x::AbstractMatrix)
         r[i] = quad(a, x[:,i])
     end
     return r
+end
+
+function invquad(a::PDSparseMat, x::AbstractVecOrMat)
+    @check_argdims a.dim == size(x, 1)
+    z = sparse(chol_lower(cholesky(a))) \ x
+    return x isa AbstractVector ? sum(abs2, z) : vec(sum(abs2, z; dims = 1))
 end
 
 function invquad!(r::AbstractArray, a::PDSparseMat, x::AbstractMatrix)

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -104,7 +104,12 @@ end
 
 function quad(a::PDSparseMat, x::AbstractVecOrMat)
     @check_argdims a.dim == size(x, 1)
-    z = sparse(chol_lower(cholesky(a)))' * x
+    # `*` is not defined for `UP` factor components,
+    # so we can't use `chol_upper(a.chol) * x`
+    # Moreover, `sparse` is only defined for `L` factor components
+    C = a.chol
+    UP = transpose(sparse(C.L))[:, C.p]
+    z = UP * x
     return x isa AbstractVector ? sum(abs2, z) : vec(sum(abs2, z; dims = 1))
 end
 
@@ -118,7 +123,7 @@ end
 
 function invquad(a::PDSparseMat, x::AbstractVecOrMat)
     @check_argdims a.dim == size(x, 1)
-    z = sparse(chol_lower(cholesky(a))) \ x
+    z = chol_lower(cholesky(a)) \ x
     return x isa AbstractVector ? sum(abs2, z) : vec(sum(abs2, z; dims = 1))
 end
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -99,20 +99,20 @@ invquad!(r::AbstractArray, a::ScalMat, x::AbstractMatrix) = colwise_sumsqinv!(r,
 
 function X_A_Xt(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
-    lmul!(a.value, x * transpose(x))
+    a.value * (x * transpose(x))
 end
 
 function Xt_A_X(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
-    lmul!(a.value, transpose(x) * x)
+    a.value * (transpose(x) * x)
 end
 
 function X_invA_Xt(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
-    _rdiv!(x * transpose(x), a.value)
+    (x * transpose(x)) / a.value
 end
 
 function Xt_invA_X(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
-    _rdiv!(transpose(x) * x, a.value)
+    (transpose(x) * x) / a.value
 end

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -111,6 +111,13 @@ function quad(a::ScalMat, x::AbstractVecOrMat)
         return vec(sum(wsq, x; dims=1))
     end
 end
+
+function quad!(r::AbstractArray, a::ScalMat, x::AbstractMatrix)
+    @check_argdims eachindex(r) == axes(x, 2)
+    @check_argdims a.dim == size(x, 1)
+    return map!(Base.Fix1(quad, a), r, eachcol(x))
+end
+
 function invquad(a::ScalMat, x::AbstractVecOrMat)
     @check_argdims a.dim == size(x, 1)
     if x isa AbstractVector
@@ -125,11 +132,6 @@ function invquad(a::ScalMat, x::AbstractVecOrMat)
     end
 end
 
-function quad!(r::AbstractArray, a::ScalMat, x::AbstractMatrix)
-    @check_argdims eachindex(r) == axes(x, 2)
-    @check_argdims a.dim == size(x, 1)
-    return map!(Base.Fix1(quad, a), r, eachcol(x))
-end
 function invquad!(r::AbstractArray, a::ScalMat, x::AbstractMatrix)
     @check_argdims eachindex(r) == axes(x, 2)
     @check_argdims a.dim == size(x, 1)

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -116,3 +116,24 @@ function Xt_invA_X(a::ScalMat, x::AbstractMatrix)
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
     (transpose(x) * x) / a.value
 end
+
+# Specializations for `x::Matrix` with reduced allocations
+function X_A_Xt(a::ScalMat, x::Matrix)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
+    lmul!(a.value, x * transpose(x))
+end
+
+function Xt_A_X(a::ScalMat, x::Matrix)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
+    lmul!(a.value, transpose(x) * x)
+end
+
+function X_invA_Xt(a::ScalMat, x::Matrix)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
+    _rdiv!(x * transpose(x), a.value)
+end
+
+function Xt_invA_X(a::ScalMat, x::Matrix)
+    @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
+    _rdiv!(transpose(x) * x, a.value)
+end

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -20,11 +20,14 @@ using StaticArrays
         @test D isa PDiagMat{Float64, <:SVector{4, Float64}}
         @test @inferred(kron(D, D)) isa PDiagMat{Float64, <:SVector{16, Float64}}
 
+        # Scaled identity matrix
+        E = ScalMat(4, 1.2)
+
         x = @SVector rand(4)
         X = @SMatrix rand(10, 4)
         Y = @SMatrix rand(4, 10)
 
-        for A in (PDS, D)
+        for A in (PDS, D, E)
             @test A * x isa SVector{4, Float64}
             @test A * x ≈ Matrix(A) * Vector(x)
 

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -43,6 +43,30 @@ using StaticArrays
             @test A \ Y isa SMatrix{4, 10, Float64}
             @test A \ Y ≈ Matrix(A) \ Matrix(Y)
 
+            @test whiten(A, x) isa SVector{4, Float64}
+            @test whiten(A, x) ≈ cholesky(Matrix(A)).L \ Vector(x)
+
+            @test whiten(A, Y) isa SMatrix{4, 10, Float64}
+            @test whiten(A, Y) ≈ cholesky(Matrix(A)).L \ Matrix(Y)
+
+            @test unwhiten(A, x) isa SVector{4, Float64}
+            @test unwhiten(A, x) ≈ cholesky(Matrix(A)).L * Vector(x)
+
+            @test unwhiten(A, Y) isa SMatrix{4, 10, Float64}
+            @test unwhiten(A, Y) ≈ cholesky(Matrix(A)).L * Matrix(Y)
+
+            @test quad(A, x) isa Float64
+            @test quad(A, x) ≈ Vector(x)' * Matrix(A) * Vector(x)
+
+            @test quad(A, Y) isa SVector{10, Float64}
+            @test quad(A, Y) ≈ diag(Matrix(Y)' * Matrix(A) * Matrix(Y))
+
+            @test invquad(A, x) isa Float64
+            @test invquad(A, x) ≈ Vector(x)' * (Matrix(A) \ Vector(x))
+
+            @test invquad(A, Y) isa SVector{10, Float64}
+            @test invquad(A, Y) ≈ diag(Matrix(Y)' * (Matrix(A) \ Matrix(Y)))
+
             @test X_A_Xt(A, X) isa SMatrix{10, 10, Float64}
             @test X_A_Xt(A, X) ≈ Matrix(X) * Matrix(A) *  Matrix(X)'
 


### PR DESCRIPTION
Based on #181, this PR also adds support for `whiten`, `unwhiten`, `quad`, and `invquad` with static arrays.

The PR grew a bit larger, hence I kept it separate from #181 for now.

Main points:
- Do not use mutation in non-mutating methods (in a few cases, allocations could be reduced by specializing on `Array`, see my comment in #181 - should we do this?)
- Improve composability by forwarding calls with generic matrices to `f(..., AbstractPDMat(x), ...)` (as a nice side effect, this means that more efficient implementations are called automatically whenever `AbstractPDMat(x)` is specialized; this is the case, e.g., for `Diagonal` matrices).
- Check dimensions.