### PR TITLE
Improve performance of tri products for `PDiagMat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.19"
+version = "0.11.20"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -160,24 +160,24 @@ end
 
 function X_A_Xt(a::PDiagMat, x::AbstractMatrix)
     @check_argdims a.dim == size(x, 2)
-    z = x .* sqrt.(permutedims(a.diag))
-    z * transpose(z)
+    z = a.diag .* x
+    return z * transpose(x)
 end
 
 function Xt_A_X(a::PDiagMat, x::AbstractMatrix)
     @check_argdims a.dim == size(x, 1)
-    z = x .* sqrt.(a.diag)
-    transpose(z) * z
+    z = a.diag .* x
+    return transpose(x) * z
 end
 
 function X_invA_Xt(a::PDiagMat, x::AbstractMatrix)
     @check_argdims a.dim == size(x, 2)
-    z = x ./ sqrt.(permutedims(a.diag))
-    z * transpose(z)
+    z = x ./ a.diag
+    return z * transpose(x)
 end
 
 function Xt_invA_X(a::PDiagMat, x::AbstractMatrix)
     @check_argdims a.dim == size(x, 1)
-    z = x ./ sqrt.(a.diag)
-    transpose(z) * z
+    z = x ./ a.diag
+    return transpose(x) * z
 end

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -160,8 +160,8 @@ end
 
 function X_A_Xt(a::PDiagMat, x::AbstractMatrix)
     @check_argdims a.dim == size(x, 2)
-    z = a.diag .* x
-    return z * transpose(x)
+    z = a.diag .* transpose(x)
+    return x * z
 end
 
 function Xt_A_X(a::PDiagMat, x::AbstractMatrix)
@@ -172,8 +172,8 @@ end
 
 function X_invA_Xt(a::PDiagMat, x::AbstractMatrix)
     @check_argdims a.dim == size(x, 2)
-    z = x ./ a.diag
-    return z * transpose(x)
+    z = transpose(x) ./ a.diag
+    return x * z
 end
 
 function Xt_invA_X(a::PDiagMat, x::AbstractMatrix)


### PR DESCRIPTION
This PR removes the `sqrt` computations and `permutedims` calls from the tri product implementations for `PDiagMat`.

## master

```julia
julia> using PDMats, BenchmarkTools

julia> a = PDiagMat(rand(10)); X = randn(10, 10);

julia> @btime Xt_A_X(a, X);
  366.343 ns (2 allocations: 1.75 KiB)

julia> @btime X_A_Xt(a, X);
  377.044 ns (4 allocations: 1.84 KiB)

julia> @btime Xt_invA_X(a, X);
  394.279 ns (2 allocations: 1.75 KiB)

julia> @btime X_invA_Xt(a, X);
  404.580 ns (4 allocations: 1.84 KiB)

julia> a = PDiagMat(rand(100)); X = randn(100, 100);

julia> @btime Xt_A_X(a, X);
  48.125 μs (4 allocations: 156.34 KiB)

julia> @btime X_A_Xt(a, X);
  46.333 μs (6 allocations: 156.44 KiB)

julia> @btime Xt_invA_X(a, X);
  52.667 μs (4 allocations: 156.34 KiB)

julia> @btime X_invA_Xt(a, X);
  49.166 μs (6 allocations: 156.44 KiB)
```

## This PR

```julia
julia> using PDMats, BenchmarkTools

julia> a = PDiagMat(rand(10)); X = randn(10, 10);

julia> @btime Xt_A_X(a, X);
  252.231 ns (2 allocations: 1.75 KiB)

julia> @btime X_A_Xt(a, X);
  261.102 ns (2 allocations: 1.75 KiB)

julia> @btime Xt_invA_X(a, X);
  252.301 ns (2 allocations: 1.75 KiB)

julia> @btime X_invA_Xt(a, X);
  264.350 ns (2 allocations: 1.75 KiB)

julia> a = PDiagMat(rand(100)); X = randn(100, 100);

julia> @btime Xt_A_X(a, X);
  38.916 μs (4 allocations: 156.34 KiB)

julia> @btime X_A_Xt(a, X);
  41.792 μs (4 allocations: 156.34 KiB)

julia> @btime Xt_invA_X(a, X);
  40.542 μs (4 allocations: 156.34 KiB)

julia> @btime X_invA_Xt(a, X);
  40.667 μs (4 allocations: 156.34 KiB)
```