### PR TITLE
Fix calls of deprecated constructors

### DIFF
--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -21,7 +21,7 @@ AbstractPDMat(A::Hermitian{<:Real,<:Diagonal{<:Real}}) = PDiagMat(A.data.diag)
 Base.convert(::Type{PDiagMat{T}}, a::PDiagMat{T}) where {T<:Real} = a
 function Base.convert(::Type{PDiagMat{T}}, a::PDiagMat) where {T<:Real}
     diag = convert(AbstractVector{T}, a.diag)
-    return PDiagMat{T,typeof(diag)}(a.dim, diag)
+    return PDiagMat{T,typeof(diag)}(diag)
 end
 Base.convert(::Type{AbstractPDMat{T}}, a::PDiagMat) where {T<:Real} = convert(PDiagMat{T}, a)
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -35,7 +35,7 @@ function Base.convert(::Type{PDMat{T}}, a::PDMat) where {T<:Real}
     chol = convert(Cholesky{T}, a.chol)
     S = typeof(chol.factors)
     mat = convert(S, a.mat)
-    return PDMat{T,S}(size(mat, 1), mat, chol)
+    return PDMat{T,S}(mat, chol)
 end
 Base.convert(::Type{AbstractPDMat{T}}, a::PDMat) where {T<:Real} = convert(PDMat{T}, a)
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -38,7 +38,7 @@ function Base.convert(::Type{PDSparseMat{T}}, a::PDSparseMat) where {T<:Real}
     # So there is no point in recomputing `cholesky(mat)` and we just reuse
     # the existing Cholesky factorization
     mat = convert(AbstractMatrix{T}, a.mat)
-    return PDSparseMat{T,typeof(mat)}(a.dim, mat, a.chol)
+    return PDSparseMat{T,typeof(mat)}(mat, a.chol)
 end
 Base.convert(::Type{AbstractPDMat{T}}, a::PDSparseMat) where {T<:Real} = convert(PDSparseMat{T}, a)
 


### PR DESCRIPTION
In the `convert` methods for `PDMat`, `PDDiagMat`, and `PDSparseMat` we call the inner constructors that were deprecated in #178. This PR fixes all calls of such deprecated constructors (can be seen e.g. in the output when running tests on Julia 1.0 and also checked with ripgrep).