### PR TITLE
Fix and test broken `quad!` and `invquad!`

### DIFF
--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -39,8 +39,8 @@ module PDMats
 
     # source files
 
-    include("chol.jl")
     include("utils.jl")
+    include("chol.jl")
 
     include("pdmat.jl")
 

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -46,22 +46,22 @@ for T in (:AbstractVector, :AbstractMatrix)
 end
 
 # quad
-function quad(A::Cholesky, x::AbstractVecOrMat)
-    @check_argdims size(A, 1) == size(x, 1)
-    if x isa AbstractVector
-        return sum(abs2, chol_upper(A) * x)
-    else
-        Z = chol_upper(A) * x
-        return vec(sum(abs2, Z; dims=1))
-    end
+function quad(A::Cholesky, x::AbstractVector)
+    @check_argdims size(A, 1) == length(x)
+    return sum(abs2, chol_upper(A) * x)
 end
-function quad!(r::AbstractArray, A::Cholesky, x::AbstractMatrix)
-    @check_argdims eachindex(r) == axes(x, 2)
-    @check_argdims size(A, 1) == size(x, 1)
+function quad(A::Cholesky, X::AbstractMatrix)
+    @check_argdims size(A, 1) == size(X, 1)
+    Z = chol_upper(A) * X
+    return vec(sum(abs2, Z; dims=1))
+end
+function quad!(r::AbstractArray, A::Cholesky, X::AbstractMatrix)
+    @check_argdims eachindex(r) == axes(X, 2)
+    @check_argdims size(A, 1) == size(X, 1)
     aU = chol_upper(A)
     z = similar(r, size(A, 1)) # buffer to save allocations
-    @inbounds for i in axes(x, 2)
-        copyto!(z, view(x, :, i))
+    @inbounds for i in axes(X, 2)
+        copyto!(z, view(X, :, i))
         lmul!(aU, z)
         r[i] = sum(abs2, z)
     end
@@ -69,22 +69,22 @@ function quad!(r::AbstractArray, A::Cholesky, x::AbstractMatrix)
 end
 
 # invquad
-function invquad(A::Cholesky, x::AbstractVecOrMat)
+function invquad(A::Cholesky, x::AbstractVector)
     @check_argdims size(A, 1) == size(x, 1)
-    if x isa AbstractVector
-        return sum(abs2, chol_lower(A) \ x)
-    else
-        Z = chol_lower(A) \ x
-        return vec(sum(abs2, Z; dims=1))
-    end
+    return sum(abs2, chol_lower(A) \ x)
 end
-function invquad!(r::AbstractArray, A::Cholesky, x::AbstractMatrix)
-    @check_argdims eachindex(r) == axes(x, 2)
-    @check_argdims size(A, 1) == size(x, 1)
+function invquad(A::Cholesky, X::AbstractMatrix) 
+    @check_argdims size(A, 1) == size(X, 1)
+    Z = chol_lower(A) \ X
+    return vec(sum(abs2, Z; dims=1))
+end
+function invquad!(r::AbstractArray, A::Cholesky, X::AbstractMatrix)
+    @check_argdims eachindex(r) == axes(X, 2)
+    @check_argdims size(A, 1) == size(X, 1)
     aL = chol_lower(A)
     z = similar(r, size(A, 1)) # buffer to save allocations
-    @inbounds for i in axes(x, 2)
-        copyto!(z, view(x, :, i))
+    @inbounds for i in axes(X, 2)
+        copyto!(z, view(X, :, i))
         ldiv!(aL, z)
         r[i] = sum(abs2, z)
     end

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -46,45 +46,73 @@ for T in (:AbstractVector, :AbstractMatrix)
 end
 
 # quad
-quad(A::Cholesky, x::AbstractVector) = sum(abs2, chol_upper(A) * x)
-function quad(A::Cholesky, X::AbstractMatrix)
-    Z = chol_upper(A) * X
-    return vec(sum(abs2, Z; dims=1))
+function quad(A::Cholesky, x::AbstractVecOrMat)
+    @check_argdims size(A, 1) == size(x, 1)
+    if x isa AbstractVector
+        return sum(abs2, chol_upper(A) * x)
+    else
+        Z = chol_upper(A) * x
+        return vec(sum(abs2, Z; dims=1))
+    end
 end
-function quad!(r::AbstractArray, A::Cholesky, X::AbstractMatrix)
-    Z = chol_upper(A) * X
-    return map!(Base.Fix1(sum, abs2), r, eachcol(Z))
+function quad!(r::AbstractArray, A::Cholesky, x::AbstractMatrix)
+    @check_argdims eachindex(r) == axes(x, 2)
+    @check_argdims size(A, 1) == size(x, 1)
+    aU = chol_upper(A)
+    z = similar(r, size(A, 1)) # buffer to save allocations
+    @inbounds for i in axes(x, 2)
+        copyto!(z, view(x, :, i))
+        lmul!(aU, z)
+        r[i] = sum(abs2, z)
+    end
+    return r
 end
 
 # invquad
-invquad(A::Cholesky, x::AbstractVector) = sum(abs2, chol_lower(A) \ x)
-function invquad(A::Cholesky, X::AbstractMatrix)
-    Z = chol_lower(A) \ X
-    return vec(sum(abs2, Z; dims=1))
+function invquad(A::Cholesky, x::AbstractVecOrMat)
+    @check_argdims size(A, 1) == size(x, 1)
+    if x isa AbstractVector
+        return sum(abs2, chol_lower(A) \ x)
+    else
+        Z = chol_lower(A) \ x
+        return vec(sum(abs2, Z; dims=1))
+    end
 end
-function invquad!(r::AbstractArray, A::Cholesky, X::AbstractMatrix)
-    Z = chol_lower(A) \ X
-    return map!(Base.Fix1(sum, abs2), r, eachcol(Z))
+function invquad!(r::AbstractArray, A::Cholesky, x::AbstractMatrix)
+    @check_argdims eachindex(r) == axes(x, 2)
+    @check_argdims size(A, 1) == size(x, 1)
+    aL = chol_lower(A)
+    z = similar(r, size(A, 1)) # buffer to save allocations
+    @inbounds for i in axes(x, 2)
+        copyto!(z, view(x, :, i))
+        ldiv!(aL, z)
+        r[i] = sum(abs2, z)
+    end
+    return r
 end
 
 # tri products
 
 function X_A_Xt(A::Cholesky, X::AbstractMatrix)
+    @check_argdims size(A, 1) == size(X, 2)
     Z = X * chol_lower(A)
     return Z * transpose(Z)
 end
 
 function Xt_A_X(A::Cholesky, X::AbstractMatrix)
+    @check_argdims size(A, 1) == size(X, 1)
     Z = chol_upper(A) * X
     return transpose(Z) * Z
 end
 
 function X_invA_Xt(A::Cholesky, X::AbstractMatrix)
+    @check_argdims size(A, 1) == size(X, 2)
     Z = X / chol_upper(A)
     return Z * transpose(Z)
 end
 
 function Xt_invA_X(A::Cholesky, X::AbstractMatrix)
+    @check_argdims size(A, 1) == size(X, 1)
     Z = chol_lower(A) \ X
     return transpose(Z) * Z
 end

--- a/src/chol.jl
+++ b/src/chol.jl
@@ -63,7 +63,7 @@ function invquad(A::Cholesky, X::AbstractMatrix)
     return vec(sum(abs2, Z; dims=1))
 end
 function invquad!(r::AbstractArray, A::Cholesky, X::AbstractMatrix)
-    Z = chol_lower(A) * X
+    Z = chol_lower(A) \ X
     return map!(Base.Fix1(sum, abs2), r, eachcol(Z))
 end
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -123,7 +123,7 @@ function quad(a::PDMat, x::AbstractVecOrMat)
 end
 
 function quad!(r::AbstractArray, a::PDMat, x::AbstractMatrix)
-    @check_argdims axes(r) == axes(x, 2)
+    @check_argdims eachindex(r) == axes(x, 2)
     @check_argdims a.dim == size(x, 1)
     aU = chol_upper(cholesky(a))
     z = similar(r, a.dim) # buffer to save allocations
@@ -146,7 +146,7 @@ function invquad(a::PDMat, x::AbstractVecOrMat)
 end
 
 function invquad!(r::AbstractArray, a::PDMat, x::AbstractMatrix)
-    @check_argdims axes(r) == axes(x, 2)
+    @check_argdims eachindex(r) == axes(x, 2)
     @check_argdims a.dim == size(x, 1)
     aL = chol_lower(cholesky(a))
     z = similar(r, a.dim) # buffer to save allocations

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -115,7 +115,10 @@ end
 function quad!(r::AbstractArray, a::ScalMat, x::AbstractMatrix)
     @check_argdims eachindex(r) == axes(x, 2)
     @check_argdims a.dim == size(x, 1)
-    return map!(Base.Fix1(quad, a), r, eachcol(x))
+    @inbounds for i in axes(x, 2)
+        r[i] = quad(a, view(x, :, i))
+    end
+    return r
 end
 
 function invquad(a::ScalMat, x::AbstractVecOrMat)
@@ -135,7 +138,10 @@ end
 function invquad!(r::AbstractArray, a::ScalMat, x::AbstractMatrix)
     @check_argdims eachindex(r) == axes(x, 2)
     @check_argdims a.dim == size(x, 1)
-    return map!(Base.Fix1(invquad, a), r, eachcol(x))
+    @inbounds for i in axes(x, 2)
+        r[i] = invquad(a, view(x, :, i))
+    end
+    return r
 end
 
 

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -47,16 +47,16 @@ using StaticArrays
             @test A \ Y ≈ Matrix(A) \ Matrix(Y)
 
             @test whiten(A, x) isa SVector{4, Float64}
-            @test whiten(A, x) ≈ cholesky(Matrix(A)).L \ Vector(x)
+            @test whiten(A, x) ≈ cholesky(Symmetric(Matrix(A))).L \ Vector(x)
 
             @test whiten(A, Y) isa SMatrix{4, 10, Float64}
-            @test whiten(A, Y) ≈ cholesky(Matrix(A)).L \ Matrix(Y)
+            @test whiten(A, Y) ≈ cholesky(Symmetric(Matrix(A))).L \ Matrix(Y)
 
             @test unwhiten(A, x) isa SVector{4, Float64}
-            @test unwhiten(A, x) ≈ cholesky(Matrix(A)).L * Vector(x)
+            @test unwhiten(A, x) ≈ cholesky(Symmetric(Matrix(A))).L * Vector(x)
 
             @test unwhiten(A, Y) isa SMatrix{4, 10, Float64}
-            @test unwhiten(A, Y) ≈ cholesky(Matrix(A)).L * Matrix(Y)
+            @test unwhiten(A, Y) ≈ cholesky(Symmetric(Matrix(A))).L * Matrix(Y)
 
             @test quad(A, x) isa Float64
             @test quad(A, x) ≈ Vector(x)' * Matrix(A) * Vector(x)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -272,6 +272,9 @@ function pdtest_quad(C, Cmat::Matrix, Imat::Matrix, X::Matrix, verbose::Int)
         @test quad(C, view(X,:,i)) ≈ r_quad[i]
     end
     @test quad(C, X) ≈ r_quad
+    r = similar(r_quad)
+    @test quad!(r, C, X) === r
+    @test r ≈ r_quad
 
     _pdt(verbose, "invquad")
     r_invquad = zeros(eltype(C),n)
@@ -282,6 +285,9 @@ function pdtest_quad(C, Cmat::Matrix, Imat::Matrix, X::Matrix, verbose::Int)
         @test invquad(C, view(X,:,i)) ≈ r_invquad[i]
     end
     @test invquad(C, X) ≈ r_invquad
+    r = similar(r_invquad)
+    @test invquad!(r, C, X) === r
+    @test r ≈ r_invquad
 end
 
 


### PR DESCRIPTION
PDMats 0.11.26 broke `invquads!` due to a bug in the check of the dimensions of the input arguments: https://github.com/JuliaStats/Distributions.jl/issues/1789

This issues was not noticed since `quad!` and `invquad!` were not tested.