### PR TITLE
Add FillArrays extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Downgrade FillArrays on Julia 1.0 to fix compat conflicts with BandedMatrices
+        if: ${{ matrix.version }} == '1.0'
+        run: |
+          import Pkg
+          Pkg.instantiate()
+          Pkg.add(Pkg.PackageSpec(; name="FillArrays", uuid="1a297f60-69ca-5386-bcde-b61e274b549b", version="0.10"))
+        shell: julia --project=. --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/Project.toml
+++ b/Project.toml
@@ -3,17 +3,26 @@ uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
 version = "0.11.27"
 
 [deps]
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
+FillArrays = "0.10, 0.11, 0.12, 1"
 julia = "1"
+
+[extensions]
+PDMatsFillArraysExt = "FillArrays"
 
 [extras]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BandedMatrices", "StaticArrays", "Test"]
+test = ["BandedMatrices", "FillArrays", "StaticArrays", "Test"]
+
+[weakdeps]
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/ext/PDMatsFillArraysExt.jl
+++ b/ext/PDMatsFillArraysExt.jl
@@ -1,0 +1,11 @@
+module PDMatsFillArraysExt
+
+using PDMats: PDMats, LinearAlgebra
+using FillArrays: FillArrays
+
+function PDMats.AbstractPDMat(a::LinearAlgebra.Diagonal{T,<:FillArrays.AbstractFill{T,1}}) where {T<:Real}
+    dim = size(a, 1)
+    return PDMats.ScalMat(dim, FillArrays.getindex_value(a.diag))
+end
+
+end # module

--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -56,4 +56,8 @@ module PDMats
 
     include("deprecates.jl")
 
+    # FillArrays support on Julia < 1.9
+    if !isdefined(Base, :get_extension)
+        include("../ext/PDMatsFillArraysExt.jl")
+    end
 end # module

--- a/test/ext.jl
+++ b/test/ext.jl
@@ -1,0 +1,10 @@
+using FillArrays
+
+@testset "PDMatsFillArraysExt" begin
+    for diag in (Ones(5), Fill(4.1, 8))
+        a = @inferred(AbstractPDMat(Diagonal(diag)))
+        @test a isa ScalMat
+        @test a.dim == length(diag)
+        @test a.value == first(diag)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 include("testutils.jl")
-tests = ["pdmtypes", "abstracttypes", "addition", "generics", "kron", "chol", "specialarrays", "sqrt"]
+tests = ["pdmtypes", "abstracttypes", "addition", "generics", "kron", "chol", "specialarrays", "sqrt", "ext"]
 println("Running tests ...")
 
 for t in tests


### PR DESCRIPTION
This is an alternative to #184 that keeps support for Julia 1.0. The issues with `Pkg.test` (incompatibilities of test dependencies with already installed package dependencies) can be avoided by enforcing the use of FillArrays 0.10 on Julia 1.0. Julia 1.0 is also supported by FillArrays 0.11 and 0.12 and hence I added them to the compat entry as well; however, the test dependencies BandedMatrices and ArrayLayouts can't be installed together with these more recent versions on Julia 1.0, hence I explicitly downgraded FillArrays to 0.10 in CI on Julia 1.0.