### PR TITLE
Typed Matrix constructor and more stable tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,17 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
+BandedMatrices = "1"
+Random = "1"
+StaticArrays = "1"
+Test = "1"
 julia = "1"
 
 [extras]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BandedMatrices", "StaticArrays", "Test"]
+test = ["BandedMatrices", "StaticArrays", "Random", "Test"]

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -29,6 +29,7 @@ Base.convert(::Type{AbstractPDMat{T}}, a::PDiagMat) where {T<:Real} = convert(PD
 
 Base.size(a::PDiagMat) = (a.dim, a.dim)
 Base.Matrix(a::PDiagMat) = Matrix(Diagonal(a.diag))
+Base.Matrix{T}(a::PDiagMat) where {T} = Matrix{T}(Diagonal(a.diag))
 LinearAlgebra.diag(a::PDiagMat) = copy(a.diag)
 LinearAlgebra.cholesky(a::PDiagMat) = Cholesky(Diagonal(map(sqrt, a.diag)), 'U', 0)
 
@@ -37,11 +38,7 @@ Base.broadcastable(a::PDiagMat) = Base.broadcastable(Diagonal(a.diag))
 
 ### Inheriting from AbstractMatrix
 
-function Base.getindex(a::PDiagMat, i::Integer)
-    ncol, nrow = fldmod1(i, a.dim)
-    ncol == nrow ? a.diag[nrow] : zero(eltype(a))
-end
-Base.getindex(a::PDiagMat{T},i::Integer,j::Integer) where {T} = i == j ? a.diag[i] : zero(T)
+Base.@propagate_inbounds Base.getindex(a::PDiagMat{T}, i::Int, j::Int) where {T} = i == j ? a.diag[i] : zero(T)
 
 ### Arithmetics
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -43,6 +43,7 @@ Base.convert(::Type{AbstractPDMat{T}}, a::PDMat) where {T<:Real} = convert(PDMat
 
 Base.size(a::PDMat) = (a.dim, a.dim)
 Base.Matrix(a::PDMat) = Matrix(a.mat)
+Base.Matrix{T}(a::PDMat) where {T} = Matrix{T}(a.mat)
 LinearAlgebra.diag(a::PDMat) = diag(a.mat)
 LinearAlgebra.cholesky(a::PDMat) = a.chol
 
@@ -51,8 +52,7 @@ Base.broadcastable(a::PDMat) = Base.broadcastable(a.mat)
 
 ### Inheriting from AbstractMatrix
 
-Base.getindex(a::PDMat, i::Int) = getindex(a.mat, i)
-Base.getindex(a::PDMat, I::Vararg{Int, N}) where {N} = getindex(a.mat, I...)
+Base.@propagate_inbounds Base.getindex(a::PDMat, I::Vararg{Int, 2}) = getindex(a.mat, I...)
 
 ### Arithmetics
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -46,13 +46,13 @@ Base.convert(::Type{AbstractPDMat{T}}, a::PDSparseMat) where {T<:Real} = convert
 
 Base.size(a::PDSparseMat) = (a.dim, a.dim)
 Base.Matrix(a::PDSparseMat) = Matrix(a.mat)
+Base.Matrix{T}(a::PDSparseMat) where {T} = Matrix{T}(a.mat)
 LinearAlgebra.diag(a::PDSparseMat) = diag(a.mat)
 LinearAlgebra.cholesky(a::PDSparseMat) = a.chol
 
 ### Inheriting from AbstractMatrix
 
-Base.getindex(a::PDSparseMat,i::Integer) = getindex(a.mat, i)
-Base.getindex(a::PDSparseMat,I::Vararg{Int, N}) where {N} = getindex(a.mat, I...)
+Base.getindex(a::PDSparseMat, I::Vararg{Int, 2}) = getindex(a.mat, I...)
 
 ### Arithmetics
 

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -4,7 +4,7 @@ using StaticArrays
 @testset "Special matrix types" begin
     @testset "StaticArrays" begin
         # Full matrix
-        S = (x -> x * x' + I)(@SMatrix(randn(4, 7)))
+        S = (x -> SMatrix{4,4}(Hermitian(x * x' + I)))(@SMatrix(randn(4, 7)))
         PDS = PDMat(S)
         @test PDS isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
         @test isbits(PDS)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -4,7 +4,9 @@
 #       the implementation of a subtype of AbstractPDMat
 #
 
-using PDMats, SuiteSparse, Test
+using PDMats, SuiteSparse, Test, Random
+
+Random.seed!(10)
 
 const HAVE_CHOLMOD = isdefined(SuiteSparse, :CHOLMOD)
 const PDMatType = HAVE_CHOLMOD ? Union{PDMat, PDSparseMat, PDiagMat} : Union{PDMat, PDiagMat}


### PR DESCRIPTION
I've removed the single-index `getindex` methods, as the `AbstractArray` fallback methods should suffice. 

I've also ensured that the matrices are explicitly hermitian in the tests, which makes it less likely for `cholesky` to fail due to numerical precision issues. Further, I've added a random seed, which makes the tests easier to reproduce.