### PR TITLE
Add versioned manifest file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build
 docs/site
 Manifest.toml
+Manifest-v*.*.toml


### PR DESCRIPTION
Julia v1.11 allows manifest files with the version in the filename, and we may ignore these as well.