### PR TITLE
Fix too optimistic definitions of `*` and `/` with scalars

### DIFF
--- a/src/congruence.jl
+++ b/src/congruence.jl
@@ -42,7 +42,10 @@ end
 
 for f in (:X_invA_Xt, :Xt_invA_X)
     @eval begin
-        $(f)(A::ScalMat, B::ScalMat) = B * (A \ B)
+        function $(f)(A::ScalMat, B::ScalMat)
+            @check_argdims A.dim == B.dim
+            return ScalMat(A.dim, B.value * (A.value \ B.value))
+        end
         $(f)(A::PDiagMat, B::PDiagMat) = PDiagMat(B.diag .* (A.diag .\ B.diag))
         $(f)(A::PDiagMat, B::ScalMat) = PDiagMat(B.value .* (A.diag .\ B.value))
         function $(f)(A::ScalMat, B::PDiagMat)

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -51,7 +51,7 @@ function pdadd!(r::Matrix, a::Matrix, b::PDiagMat, c)
     return r
 end
 
-*(a::PDiagMat, c::Real) = PDiagMat(a.diag * c)
+*(a::PDiagMat, c::Real) = Diagonal(a.diag) * c
 function *(a::PDiagMat, x::AbstractVector)
     @check_argdims a.dim == length(x)
     return a.diag .* x

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -93,7 +93,7 @@ function pdadd!(r::Matrix, a::Matrix, b::PDMat, c)
     return _addscal!(r, a, b.mat, c)
 end
 
-*(a::PDMat, c::Real) = PDMat(a.mat * c)
+*(a::PDMat, c::Real) = a.mat * c
 *(a::PDMat, x::AbstractVector) = a.mat * x
 *(a::PDMat, x::AbstractMatrix) = a.mat * x
 \(a::PDMat, x::AbstractVecOrMat) = a.chol \ x

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -65,7 +65,7 @@ function pdadd!(r::Matrix, a::Matrix, b::PDSparseMat, c)
     return _addscal!(r, a, b.mat, c)
 end
 
-*(a::PDSparseMat, c::Real) = PDSparseMat(a.mat * c)
+*(a::PDSparseMat, c::Real) = a.mat * c
 *(a::PDSparseMat, x::AbstractMatrix) = a.mat * x  # defining these seperately to avoid
 *(a::PDSparseMat, x::AbstractVector) = a.mat * x  # ambiguity errors
 \(a::PDSparseMat{T}, x::AbstractVecOrMat{T}) where {T <: Real} = convert(Array{T}, a.chol \ convert(Array{Float64}, x)) #to avoid limitations in sparse factorization library CHOLMOD, see e.g., julia issue #14076

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -38,8 +38,8 @@ function pdadd!(r::Matrix, a::Matrix, b::ScalMat, c)
     return r
 end
 
-*(a::ScalMat, c::Real) = ScalMat(a.dim, a.value * c)
-/(a::ScalMat, c::Real) = ScalMat(a.dim, a.value / c)
+*(a::ScalMat, c::Real) = Diagonal(fill(a.value * c, a.dim))
+/(a::ScalMat, c::Real) = Diagonal(fill(a.value / c, a.dim))
 function *(a::ScalMat, x::AbstractVector)
     @check_argdims a.dim == length(x)
     return a.value * x

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -157,8 +157,20 @@ end
 
 function pdtest_scale(C, Cmat::Matrix, verbose::Int)
     _pdt(verbose, "scale")
-    @test Matrix(C * convert(eltype(C), 2)) ≈ Cmat * convert(eltype(C), 2)
-    return @test Matrix(convert(eltype(C), 2) * C) ≈ convert(eltype(C), 2) * Cmat
+    for c in (2, -2, 2.0f0, -2.0f0, 2.0, -2.0)
+        T = promote_type(eltype(C), typeof(c))
+
+        M = @inferred(c * C)
+        @test M isa AbstractMatrix{T}
+        @test !(M isa AbstractPDMat)
+        @test M ≈ c * Cmat
+
+        M = @inferred(C * c)
+        @test M isa AbstractMatrix{T}
+        @test !(M isa AbstractPDMat)
+        @test M ≈ Cmat * c
+    end
+    return nothing
 end
 
 


### PR DESCRIPTION
The definitions of `*` and `/` for pd matrices are too optimistic: In general, the resulting matrix is not pd (or psd) anymore, so we should not return a pd matrix type (which currently - at least some of them - do not even check positive definiteness at construction!).

If a pd matrix type is desired, then I guess either one should use a dedicated function or encode in the type domain of the scalar that it is positive (or at least non-negative).

Ref #201.