### PR TITLE
Separate parent matrix type from Cholesky parameter

### DIFF
--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -1,11 +1,11 @@
 """
 Full positive definite matrix together with a Cholesky factorization object.
 """
-struct PDMat{T<:Real,S<:AbstractMatrix} <: AbstractPDMat{T}
-    mat::S
+struct PDMat{T<:Real,S<:AbstractMatrix{T},M<:AbstractMatrix{T}} <: AbstractPDMat{T}
+    mat::M
     chol::Cholesky{T,S}
 
-    PDMat{T,S}(m::AbstractMatrix{T},c::Cholesky{T,S}) where {T,S} = new{T,S}(m,c)
+    PDMat{T,S}(m::M, c::Cholesky{T,S}) where {T,S<:AbstractMatrix{T},M<:AbstractMatrix{T}} = new{T,S,M}(m,c)
 end
 
 function PDMat(mat::AbstractMatrix,chol::Cholesky{T,S}) where {T,S}
@@ -13,7 +13,7 @@ function PDMat(mat::AbstractMatrix,chol::Cholesky{T,S}) where {T,S}
     if size(chol, 1) != d
         throw(DimensionMismatch("Dimensions of mat and chol are inconsistent."))
     end
-    PDMat{T,S}(convert(S, mat), chol)
+    PDMat{T,S}(convert(AbstractMatrix{T}, mat), chol)
 end
 
 PDMat(mat::AbstractMatrix) = PDMat(mat, cholesky(mat))

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -164,6 +164,11 @@ using Test
         end
     end
 
+    @testset "PDMat fro SymTridiagonal" begin
+        S = SymTridiagonal(fill(4,4), fill(1,3))
+        @test PDMat(S) == S
+    end
+
     @testset "AbstractPDMat constructors (#136)" begin
         x = rand(10, 10)
         A = Array(Symmetric(x' * x + I))


### PR DESCRIPTION
This adds an extra type parameter to `PDMat` corresponding to the parent matrix type. This lets the `PDMat` constructor succeed even if the parent type doesn't match those of the Cholesky factors. E.g. the following works after this:

```julia
julia> S = SymTridiagonal(fill(4,4), fill(1,3))
4×4 SymTridiagonal{Int64, Vector{Int64}}:
 4  1  ⋅  ⋅
 1  4  1  ⋅
 ⋅  1  4  1
 ⋅  ⋅  1  4

julia> PDMat(S)
4×4 PDMat{Float64, Bidiagonal{Float64, Vector{Float64}}, SymTridiagonal{Float64, Vector{Float64}}}:
 4.0  1.0  0.0  0.0
 1.0  4.0  1.0  0.0
 0.0  1.0  4.0  1.0
 0.0  0.0  1.0  4.0
```
where the Cholesky factors are `Bidiagonal`, but the parent is a `SymTridiagonal`.