### PR TITLE
Implement dot product

### DIFF
--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -203,3 +203,9 @@ function invquad(a::PDiagMat{<:Real,<:Vector}, x::Matrix)
     return invquad!(Vector{T}(undef, size(x, 2)), a, x)
 end
 
+### dot product
+
+function LinearAlgebra.dot(x::AbstractVector, a::PDiagMat, y::AbstractVector)
+    dot(x, Diagonal(a.diag), y)
+end
+

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -187,3 +187,9 @@ function Xt_invA_X(a::ScalMat, x::Matrix{<:Real})
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
     return Symmetric(_rdiv!(transpose(x) * x, a.value))
 end
+
+### dot product
+
+function LinearAlgebra.dot(x::AbstractVector, a::ScalMat, y::AbstractVector)
+    dot(x, UniformScaling(a.value), y)
+end

--- a/test/generics.jl
+++ b/test/generics.jl
@@ -28,3 +28,13 @@ end
 @test isposdef(PDMat([1.0 0.0; 0.0 1.0]))
 @test isposdef(PDiagMat([1.0, 1.0]))
 @test isposdef(ScalMat(2, 3.0))
+
+@testset "dot products" begin
+    pm1 = PDiagMat([1., 2., 3.])
+    pm2 = ScalMat(3, 2.)
+    x = [13., 42., .7]
+    y = [0.5, .125, 20.24]
+
+    @test dot(x, pm1, y) ≈ dot(x, Matrix(pm1), y)
+    @test dot(x, pm2, y) ≈ dot(x, Matrix(pm2), y)
+end


### PR DESCRIPTION
Currently, calling `LinearAlgebra.dot(x, A, y)` for an `AbstractPDMat` `A` falls back to the default implementation for `A::AbstractMatrix`. Especially for `A::PDiagMat` and `A::ScalMat` that is pretty wasteful, so I implemented the three-argument `dot` function in terms of `LinearAlgebra.Diagonal` and `LinearAlgebra.UniformScaling`, respectively.

Does it make sense to implement a special case for `A::PDMat` as well? Something similar to the `quad` function?
Also, is the test I added at a suitable location?