### PR TITLE
Update Julia compat to 1.10 and update CI setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -29,10 +29,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-          arch: x64
       - uses: julia-actions/julia-buildpkg@v1
       - name: Clone Downstream
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ (matrix.arch == '') && runner.arch || matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -37,7 +37,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          arch: ${{ (matrix.arch == '') && runner.arch || matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ (matrix.arch == '') && runner.arch || matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ (matrix.arch == '') && 'default' || matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,44 +12,38 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.6'
+          - 'min'
+          - 'lts'
           - '1'
-          - nightly
+          - 'pre'
         os:
-          - ubuntu-latest
+          - ubuntu-latest # Apple Silicon
+          - macOS-latest
+          - windows-latest
         arch:
-          - x64
-          - x86
+          - ''
         include:
-          - os: macOS-latest
-            arch: x64
-            version: 1
-          - os: windows-latest
-            arch: x64
+          - os: ubuntu-latest
+            arch: x86
             version: 1
           - os: windows-latest
             arch: x86
             version: 1
+          - os: macOS-13 # Intel
+            arch: ''
+            version: 1
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
           - '1'
           - 'pre'
         os:
-          - ubuntu-latest # Apple Silicon
-          - macOS-latest
+          - ubuntu-latest
+          - macOS-latest # Apple Silicon
           - windows-latest
         arch:
           - ''

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ BandedMatrices = "0.15, 1"
 Random = "<0.0.1, 1"
 StaticArrays = "1"
 Test = "<0.0.1, 1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -66,12 +66,7 @@ function \(a::PDiagMat, x::AbstractVecOrMat)
 end
 function /(x::AbstractVecOrMat, a::PDiagMat)
     @check_argdims a.dim == size(x, 2)
-    if VERSION < v"1.9-"
-        # return matrix for 1-element vectors `x`, consistent with LinearAlgebra < 1.9
-        return reshape(x, Val(2)) ./ permutedims(a.diag) # = (a' \ x')'
-    else
-        return x ./ (x isa AbstractVector ? a.diag : a.diag')
-    end
+    return x ./ (x isa AbstractVector ? a.diag : a.diag')
 end
 Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat(vec(permutedims(A.diag) .* B.diag))
 

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -70,15 +70,10 @@ end
 \(a::PDMat, x::AbstractVecOrMat) = a.chol \ x
 function /(x::AbstractVecOrMat, a::PDMat)
     # /(::AbstractVector, ::Cholesky) is not defined
-    if VERSION < v"1.9-"
-        # return matrix for 1-element vectors `x`, consistent with LinearAlgebra
-        return reshape(x, Val(2)) / a.chol
+    if x isa AbstractVector
+        return vec(reshape(x, Val(2)) / a.chol)
     else
-        if x isa AbstractVector
-            return vec(reshape(x, Val(2)) / a.chol)
-        else
-            return x / a.chol
-        end
+        return x / a.chol
     end
 end
 

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -115,26 +115,14 @@ end
 
 function quad(a::PDSparseMat, x::AbstractVecOrMat)
     @check_argdims a.dim == size(x, 1)
-    # https://github.com/JuliaLang/julia/commit/2425ae760fb5151c5c7dd0554e87c5fc9e24de73
-    if VERSION < v"1.4.0-DEV.92"
-        z = a.mat * x
-        return x isa AbstractVector ? dot(x, z) : map(dot, eachcol(x), eachcol(z))
-    else
-        return x isa AbstractVector ? dot(x, a.mat, x) : map(Base.Fix1(quad, a), eachcol(x))
-    end
+    return x isa AbstractVector ? dot(x, a.mat, x) : map(Base.Fix1(quad, a), eachcol(x))
 end
 
 function quad!(r::AbstractArray, a::PDSparseMat, x::AbstractMatrix)
     @check_argdims eachindex(r) == axes(x, 2)
     @inbounds for i in axes(x, 2)
         xi = view(x, :, i)
-        # https://github.com/JuliaLang/julia/commit/2425ae760fb5151c5c7dd0554e87c5fc9e24de73
-        if VERSION < v"1.4.0-DEV.92"
-            # Can't use `lmul!` with buffer due to missing support in SparseArrays
-            r[i] = dot(xi, a.mat * xi)
-        else
-            r[i] = dot(xi, a.mat, xi)
-        end
+        r[i] = dot(xi, a.mat, xi)
     end
     return r
 end

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -54,12 +54,7 @@ function \(a::ScalMat, x::AbstractVecOrMat)
 end
 function /(x::AbstractVecOrMat, a::ScalMat)
     @check_argdims a.dim == size(x, 2)
-    if VERSION < v"1.9-"
-        # return matrix for 1-element vectors `x`, consistent with LinearAlgebra < 1.9
-        return reshape(x, Val(2)) / a.value
-    else
-        return x / a.value
-    end
+    return x / a.value
 end
 Base.kron(A::ScalMat, B::ScalMat) = ScalMat(A.dim * B.dim, A.value * B.value )
 
@@ -78,7 +73,7 @@ LinearAlgebra.sqrt(a::ScalMat) = ScalMat(a.dim, sqrt(a.value))
 function whiten!(r::AbstractVecOrMat, a::ScalMat, x::AbstractVecOrMat)
     @check_argdims axes(r) == axes(x)
     @check_argdims a.dim == size(x, 1)
-    _ldiv!(r, sqrt(a.value), x)
+    ldiv!(r, sqrt(a.value), x)
 end
 
 function unwhiten!(r::AbstractVecOrMat, a::ScalMat, x::AbstractVecOrMat)
@@ -180,10 +175,10 @@ end
 
 function X_invA_Xt(a::ScalMat, x::Matrix{<:Real})
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 2)
-    return Symmetric(_rdiv!(x * transpose(x), a.value))
+    return Symmetric(rdiv!(x * transpose(x), a.value))
 end
 
 function Xt_invA_X(a::ScalMat, x::Matrix{<:Real})
     @check_argdims LinearAlgebra.checksquare(a) == size(x, 1)
-    return Symmetric(_rdiv!(transpose(x) * x, a.value))
+    return Symmetric(rdiv!(transpose(x) * x, a.value))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -103,29 +103,3 @@ function colwise_sumsqinv!(r::AbstractArray, a::AbstractMatrix, c::Real)
     end
     return r
 end
-
-# `rdiv!(::AbstractArray, ::Number)` was introduced in Julia 1.2
-# https://github.com/JuliaLang/julia/pull/31179
-@static if VERSION < v"1.2.0-DEV.385"
-    function _rdiv!(X::AbstractArray, s::Number)
-        @simd for I in eachindex(X)
-            @inbounds X[I] /= s
-        end
-        X
-    end
-else
-    _rdiv!(X::AbstractArray, s::Number) = rdiv!(X, s)
-end
-
-# `ldiv!(::AbstractArray, ::Number, ::AbstractArray)` was introduced in Julia 1.4
-# https://github.com/JuliaLang/julia/pull/33806
-@static if VERSION < v"1.4.0-DEV.635"
-    _ldiv!(Y::AbstractArray, s::Number, X::AbstractArray) = Y .= s .\ X
-else
-    _ldiv!(Y::AbstractArray, s::Number, X::AbstractArray) = ldiv!(Y, s, X)
-end
-
-# https://github.com/JuliaLang/julia/pull/29749
-if VERSION < v"1.1.0-DEV.792"
-    eachcol(A::AbstractVecOrMat) = (view(A, :, i) for i in axes(A, 2))
-end

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -134,13 +134,10 @@ using Test
             @test z ≈ y
         end
 
-        # requires https://github.com/JuliaLang/julia/pull/32594
-        if VERSION >= v"1.3.0-DEV.562"
-            z = x / PDMat(A)
-            @test typeof(z) === typeof(y)
-            @test size(z) == size(y)
-            @test z ≈ y
-        end
+        z = x / PDMat(A)
+        @test typeof(z) === typeof(y)
+        @test size(z) == size(y)
+        @test z ≈ y
 
         # right division not defined for CHOLMOD:
         # `rdiv!(::Matrix{Float64}, ::SuiteSparse.CHOLMOD.Factor{Float64})` not defined
@@ -154,14 +151,11 @@ using Test
 
     @testset "PDMat from Cholesky decomposition of diagonal matrix (#137)" begin
         # U'*U where U isa UpperTriangular etc.
-        # requires https://github.com/JuliaLang/julia/pull/33334
-        if VERSION >= v"1.4.0-DEV.286"
-            x = rand(10, 10)
-            A = Diagonal(x' * x)
-            M = PDMat(cholesky(A))
-            @test M isa PDMat{Float64, typeof(A)}
-            @test Matrix(M) ≈ A
-        end
+        x = rand(10, 10)
+        A = Diagonal(x' * x)
+        M = PDMat(cholesky(A))
+        @test M isa PDMat{Float64, typeof(A)}
+        @test Matrix(M) ≈ A
     end
 
     @testset "AbstractPDMat constructors (#136)" begin
@@ -204,12 +198,7 @@ using Test
         @test Mat32 isa Matrix{Float32}
         @test Mat32 ≈ Float32.(A)
 
-        if VERSION < v"1.6"
-            # inference fails e.g. on Julia 1.0
-            M = AbstractPDMat(cholesky(sparse(A)))
-        else
-            M = @inferred AbstractPDMat(cholesky(sparse(A)))
-        end
+        M = @inferred AbstractPDMat(cholesky(sparse(A)))
         @test M isa PDSparseMat
         @test Matrix(M) ≈ A
     end

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -113,10 +113,7 @@ using StaticArrays
         Y = rand(5, 2)
         @test P * x ≈ x
         @test P * Y ≈ Y
-        # Right division with Cholesky requires https://github.com/JuliaLang/julia/pull/32594
-        if VERSION >= v"1.3.0-DEV.562"
-            @test X / P ≈ X
-        end
+        @test X / P ≈ X
         @test P \ x ≈ x
         @test P \ Y ≈ Y
         @test X_A_Xt(P, X) ≈ X * X'

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -244,10 +244,9 @@ function pdtest_div(C, Imat::Matrix, X::Matrix, verbose::Int)
     @assert d == size(C, 1) == size(C, 2)
     @assert size(Imat) == size(C)
     @test C \ X ≈ Imat * X
-    # Right division with Choleskyrequires https://github.com/JuliaLang/julia/pull/32594
     # CHOLMOD throws error since no method is found for
     # `rdiv!(::Matrix{Float64}, ::SuiteSparse.CHOLMOD.Factor{Float64})`
-    check_rdiv = !(C isa PDMat && VERSION < v"1.3.0-DEV.562") && !(C isa PDSparseMat && HAVE_CHOLMOD)
+    check_rdiv = !(C isa PDSparseMat && HAVE_CHOLMOD)
     check_rdiv && @test Matrix(X') / C ≈ (C \ X)'
 
     for i = 1:n


### PR DESCRIPTION
In https://github.com/JuliaStats/PDMats.jl/pull/212, it was proposed to update the Julia compat to 1.10. I opened a separate PR for this move since there are quite many `VERSION` checks that we could (and should) get rid of in this update but these changes are really unrelated to #212 otherwise.

I used the opportunity to update the CI setup, and in particular add tests with `min`, `lts` and `pre`.