### PR TITLE
Overload congruent transforms for AbstractPDMat return types

### DIFF
--- a/src/PDMats.jl
+++ b/src/PDMats.jl
@@ -53,6 +53,7 @@ include("scalmat.jl")
 
 include("generics.jl")
 include("addition.jl")
+include("congruent.jl")
 
 include("deprecates.jl")
 

--- a/src/congruent.jl
+++ b/src/congruent.jl
@@ -1,0 +1,53 @@
+# Congruent transforms X_A_Xt, Xt_A_X, X_invA_Xt, Xt_invA_X for guaranteed PD return values
+
+for f in (:X_A_Xt, :Xt_A_X)
+    @eval begin
+        function $(f)(A::ScalMat, B::ScalMat)
+            @check_argdims A.dim == B.dim
+            return ScalMat(A.dim, abs2(B.value) * A.value)
+        end
+        $(f)(A::PDiagMat, B::PDiagMat) = PDiagMat(abs2.(B.diag) .* A.diag)
+        $(f)(A::PDiagMat, B::ScalMat) = PDiagMat(abs2(B.value) .* A.diag)
+        function $(f)(A::ScalMat, B::PDiagMat)
+            @check_argdims A.dim == size(B, 1)
+            return PDiagMat(abs2.(B.diag) .* A.value)
+        end
+        function $(f)(A::PDMat, B::ScalMat)
+            @check_argdims B.dim == size(A, 1)
+            b2 = abs2(B.value)
+            mat = b2 * A.mat
+            uplo = A.chol.uplo
+            if uplo === 'U'
+                factors = A.chol.factors * B.value'
+            else
+                factors = B.value * A.chol.factors
+            end
+            chol = Cholesky(factors, uplo, A.chol.info)
+            return PDMat(mat, chol)
+        end
+        function $(f)(A::PDMat, B::PDiagMat)
+            b = B.diag
+            mat = A.mat .* (b .* b')
+            uplo = A.chol.uplo
+            if uplo === 'U'
+                factors = A.chol.factors .* b'
+            else
+                factors = b .* A.chol.factors
+            end
+            chol = Cholesky(factors, uplo, A.chol.info)
+            return PDMat(mat, chol)
+        end
+    end
+end
+
+for f in (:X_invA_Xt, :Xt_invA_X)
+    @eval begin
+        $(f)(A::ScalMat, B::ScalMat) = B * (A \ B)
+        $(f)(A::PDiagMat, B::PDiagMat) = PDiagMat(B.diag .* (A.diag .\ B.diag))
+        $(f)(A::PDiagMat, B::ScalMat) = PDiagMat(B.value .* (A.diag .\ B.value))
+        function $(f)(A::ScalMat, B::PDiagMat)
+            @check_argdims A.dim == size(B, 1)
+            return PDiagMat(B.diag .* (A.value .\ B.diag))
+        end
+    end
+end

--- a/test/congruent.jl
+++ b/test/congruent.jl
@@ -1,0 +1,32 @@
+using LinearAlgebra, PDMats, Test
+
+@testset "Congruency transforms with PD return values" begin
+    shared_typemaps = [
+        (ScalMat, ScalMat) => ScalMat,
+        (ScalMat, PDiagMat) => PDiagMat,
+        (PDiagMat, ScalMat) => PDiagMat,
+        (PDiagMat, PDiagMat) => PDiagMat,
+    ]
+    typemaps = [shared_typemaps..., (PDMat, ScalMat) => PDMat, (PDMat, PDiagMat) => PDMat]
+    inv_typemaps = shared_typemaps
+
+    for (fs, tmaps) in
+        [((X_A_Xt, Xt_A_X), typemaps), ((X_invA_Xt, Xt_invA_X), inv_typemaps)]
+        @testset "$f(::$TA, ::$TB) -> $Tret" for ((TA, TB), Tret) in tmaps, f in fs
+            @testset for T in [Float32, Float64],
+                n in [3, 5],
+                uplo in (TA <: PDMat ? ('L', 'U') : (nothing,))
+
+                A = _rand(TA, T, n, uplo)
+                B = _rand(TB, T, n, uplo)
+                ret = @inferred f(A, B)
+                @test ret isa Tret{T}
+                @test ret ≈ f(A, Matrix(B))
+                if Tret <: PDMat
+                    @test cholesky(ret).uplo == cholesky(A).uplo
+                    @test Matrix(cholesky(ret)) ≈ ret.mat
+                end
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 include("testutils.jl")
-tests = ["pdmtypes", "abstracttypes", "addition", "generics", "kron", "chol", "specialarrays", "sqrt", "ad"]
+tests = ["pdmtypes", "abstracttypes", "addition", "congruent", "generics", "kron", "chol", "specialarrays", "sqrt", "ad"]
 println("Running tests ...")
 
 for t in tests

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -373,6 +373,16 @@ _randPDiagMat(T, n) = PDiagMat(rand(T, n))
 _randScalMat(T, n) = ScalMat(n, rand(T))
 _randPDSparseMat(T, n) = (X = T.(sprand(n, 1, 0.5)); PDSparseMat(X * X' + LinearAlgebra.I))
 
+function _rand(::Type{PDMat}, T, n, uplo::Char)
+    X = _randPDMat(T, n)
+    cholX = cholesky(X)
+    cholX.uplo === uplo && return X
+    (; factors, info) = cholX
+    return PDMat(Cholesky(Matrix(factors'), uplo, info))
+end
+_rand(::Type{PDiagMat}, T, n, _) = _randPDiagMat(T, n)
+_rand(::Type{ScalMat}, T, n, _) = _randScalMat(T, n)
+
 function _pd_compare(A::AbstractPDMat, B::AbstractPDMat)
     @test size(A) == size(B)
     @test Matrix(A) ≈ Matrix(B)


### PR DESCRIPTION
As discussed in https://github.com/JuliaStats/PDMats.jl/issues/132#issuecomment-2830828344, this PR overloads `X_A_Xt`, `Xt_A_X`, `X_invA_Xt`, and `Xt_invA_X` to return the appropriate PDMats type when we can guarantee the return type is an `AbstractPDMat` and when it doesn't require computing a new composition. Fixes #132.