### PR TITLE
Remove CI tests on Intel macs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - 'pre'
         os:
           - ubuntu-latest
-          - macOS-latest # Apple Silicon
+          - macOS-latest
           - windows-latest
         arch:
           - ''
@@ -28,9 +28,6 @@ jobs:
             version: 1
           - os: windows-latest
             arch: x86
-            version: 1
-          - os: macOS-13 # Intel
-            arch: ''
             version: 1
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
It seems on the master branch some allocation tests pass on Intel macs but not on other hardware. However, since the days of Intel macs are numbered, I think instead of tweaking our tests based on the hardware architecture it might be simpler to just disable running CI on Intel macs. 