### PR TITLE
Optimize `mul!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.37"
+version = "0.11.38"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pdiagmat.jl
+++ b/src/pdiagmat.jl
@@ -70,6 +70,15 @@ function /(x::AbstractVecOrMat, a::PDiagMat)
 end
 Base.kron(A::PDiagMat, B::PDiagMat) = PDiagMat(vec(permutedims(A.diag) .* B.diag))
 
+LinearAlgebra.mul!(y::AbstractVector, a::PDiagMat, x::AbstractVector, α::Number, β::Number) = mul!(y, Diagonal(a.diag), x, α, β)
+@static if isdefined(LinearAlgebra, :AbstractTriangular)
+    LinearAlgebra.mul!(y::AbstractMatrix, a::PDiagMat, x::LinearAlgebra.AbstractTriangular, α::Number, β::Number) = mul!(y, Diagonal(a.diag), x, α, β)   # ambiguity resolution
+end
+@static if isdefined(LinearAlgebra, :BandedMatrix)
+    LinearAlgebra.mul!(y::AbstractMatrix, a::PDiagMat, x::LinearAlgebra.BandedMatrix, α::Number, β::Number) = mul!(y, Diagonal(a.diag), x, α, β)   # ambiguity resolution
+end
+LinearAlgebra.mul!(y::AbstractMatrix, a::PDiagMat, x::AbstractMatrix, α::Number, β::Number) = mul!(y, Diagonal(a.diag), x, α, β)
+
 ### Algebra
 
 Base.inv(a::PDiagMat) = PDiagMat(map(inv, a.diag))

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -106,6 +106,15 @@ function /(x::AbstractVecOrMat, a::PDMat)
     end
 end
 
+LinearAlgebra.mul!(y::AbstractVector, a::PDMat, x::AbstractVector, α::Number, β::Number) = mul!(y, a.mat, x, α, β)
+@static if isdefined(LinearAlgebra, :AbstractTriangular)
+    LinearAlgebra.mul!(y::AbstractMatrix, a::PDMat, x::LinearAlgebra.AbstractTriangular, α::Number, β::Number) = mul!(y, a.mat, x, α, β)   # ambiguity resolution
+end
+@static if isdefined(LinearAlgebra, :BandedMatrix)
+    LinearAlgebra.mul!(y::AbstractMatrix, a::PDMat, x::LinearAlgebra.BandedMatrix, α::Number, β::Number) = mul!(y, a.mat, x, α, β)   # ambiguity resolution
+end
+LinearAlgebra.mul!(y::AbstractMatrix, a::PDMat, x::AbstractMatrix, α::Number, β::Number) = mul!(y, a.mat, x, α, β)
+
 ### Algebra
 
 Base.inv(a::PDMat) = PDMat(inv(a.chol))

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -71,6 +71,15 @@ end
 \(a::PDSparseMat{T}, x::AbstractVecOrMat{T}) where {T <: Real} = convert(Array{T}, a.chol \ convert(Array{Float64}, x)) #to avoid limitations in sparse factorization library CHOLMOD, see e.g., julia issue #14076
 /(x::AbstractVecOrMat{T}, a::PDSparseMat{T}) where {T <: Real} = convert(Array{T}, convert(Array{Float64}, x) / a.chol)
 
+LinearAlgebra.mul!(y::AbstractVector, a::PDSparseMat, x::AbstractVector, α::Number, β::Number) = mul!(y, a.mat, x, α, β)
+@static if isdefined(LinearAlgebra, :AbstractTriangular)
+    LinearAlgebra.mul!(y::AbstractMatrix, a::PDSparseMat, x::LinearAlgebra.AbstractTriangular, α::Number, β::Number) = mul!(y, a.mat, x, α, β)   # ambiguity resolution
+end
+@static if isdefined(LinearAlgebra, :BandedMatrix)
+    LinearAlgebra.mul!(y::AbstractMatrix, a::PDSparseMat, x::LinearAlgebra.BandedMatrix, α::Number, β::Number) = mul!(y, a.mat, x, α, β)   # ambiguity resolution
+end
+LinearAlgebra.mul!(y::AbstractMatrix, a::PDSparseMat, x::AbstractMatrix, α::Number, β::Number) = mul!(y, a.mat, x, α, β)
+
 ### Algebra
 
 Base.inv(a::PDSparseMat{T}) where {T <: Real} = PDMat(inv(a.mat))

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -58,6 +58,15 @@ function /(x::AbstractVecOrMat, a::ScalMat)
 end
 Base.kron(A::ScalMat, B::ScalMat) = ScalMat(A.dim * B.dim, A.value * B.value)
 
+LinearAlgebra.mul!(y::AbstractVector, a::ScalMat, x::AbstractVector, α::Number, β::Number) = mul!(y, a.value, x, α, β)
+@static if isdefined(LinearAlgebra, :AbstractTriangular)
+    LinearAlgebra.mul!(y::AbstractMatrix, a::ScalMat, x::LinearAlgebra.AbstractTriangular, α::Number, β::Number) = mul!(y, a.value, x, α, β)   # ambiguity resolution
+end
+@static if isdefined(LinearAlgebra, :BandedMatrix)
+    LinearAlgebra.mul!(y::AbstractMatrix, a::ScalMat, x::LinearAlgebra.BandedMatrix, α::Number, β::Number) = mul!(y, a.value, x, α, β)   # ambiguity resolution
+end
+LinearAlgebra.mul!(y::AbstractMatrix, a::ScalMat, x::AbstractMatrix, α::Number, β::Number) = mul!(y, a.value, x, α, β)
+
 ### Algebra
 
 Base.inv(a::ScalMat) = ScalMat(a.dim, inv(a.value))


### PR DESCRIPTION
At least for `PDSparseMat`, `mul!` was falling back to the generic (indexing-based) implementation. This adds specialized `mul!` methods that delegate to the underlying matrix representation, improving performance.