### PR TITLE
Fix a few bugs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.37"
+version = "0.11.38"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -21,7 +21,6 @@ pdadd(a::Matrix{T}, b::AbstractPDMat{S}) where {T <: Real, S <: Real} = pdadd!(s
 +(a::Matrix, b::AbstractPDMat) = pdadd(a, b)
 +(a::AbstractPDMat, b::Matrix) = pdadd(b, a)
 
-*(a::AbstractPDMat, c::T) where {T <: Real} = a * c
 *(c::T, a::AbstractPDMat) where {T <: Real} = a * c
 /(a::AbstractPDMat, c::T) where {T <: Real} = a * inv(c)
 Base.kron(A::AbstractPDMat, B::AbstractPDMat) = PDMat(kron(Matrix(A), Matrix(B)))

--- a/src/pdmat.jl
+++ b/src/pdmat.jl
@@ -251,13 +251,13 @@ end
 
 ### Specializations for `Array` arguments with reduced allocations
 
-function quad(a::PDMat{<:Real, <:Vector}, x::Matrix)
+function quad(a::PDMat{<:Real, <:Matrix}, x::Matrix)
     @check_argdims a.dim == size(x, 1)
     T = typeof(zero(eltype(a)) * abs2(zero(eltype(x))))
     return quad!(Vector{T}(undef, size(x, 2)), a, x)
 end
 
-function invquad(a::PDMat{<:Real, <:Vector}, x::Matrix)
+function invquad(a::PDMat{<:Real, <:Matrix}, x::Matrix)
     @check_argdims a.dim == size(x, 1)
     T = typeof(abs2(zero(eltype(x))) / zero(eltype(a)))
     return invquad!(Vector{T}(undef, size(x, 2)), a, x)

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -76,8 +76,9 @@ function \(a::PDSparseMat, x::AbstractVecOrMat{<:Real})
 end
 function /(x::AbstractVecOrMat{<:Real}, a::PDSparseMat)
     @check_argdims a.dim == size(x, 2)
-    T = promote_type(eltype(a), eltype(x))
-    return convert(Array{T}, convert(Array{Float64}, x) / a.chol)
+    # CHOLMOD does not support `/`, but `a` is symmetric: `x / a == (a \ xᵀ)ᵀ`.
+    z = a \ transpose(x)
+    return x isa AbstractVector ? vec(z) : permutedims(z)
 end
 
 ### Algebra

--- a/src/pdsparsemat.jl
+++ b/src/pdsparsemat.jl
@@ -68,8 +68,17 @@ end
 *(a::PDSparseMat, c::Real) = PDSparseMat(a.mat * c)
 *(a::PDSparseMat, x::AbstractMatrix) = a.mat * x  # defining these seperately to avoid
 *(a::PDSparseMat, x::AbstractVector) = a.mat * x  # ambiguity errors
-\(a::PDSparseMat{T}, x::AbstractVecOrMat{T}) where {T <: Real} = convert(Array{T}, a.chol \ convert(Array{Float64}, x)) #to avoid limitations in sparse factorization library CHOLMOD, see e.g., julia issue #14076
-/(x::AbstractVecOrMat{T}, a::PDSparseMat{T}) where {T <: Real} = convert(Array{T}, convert(Array{Float64}, x) / a.chol)
+# `x` is converted to `Float64` to work around CHOLMOD limitations (julia issue #14076).
+function \(a::PDSparseMat, x::AbstractVecOrMat{<:Real})
+    @check_argdims a.dim == size(x, 1)
+    T = promote_type(eltype(a), eltype(x))
+    return convert(Array{T}, a.chol \ convert(Array{Float64}, x))
+end
+function /(x::AbstractVecOrMat{<:Real}, a::PDSparseMat)
+    @check_argdims a.dim == size(x, 2)
+    T = promote_type(eltype(a), eltype(x))
+    return convert(Array{T}, convert(Array{Float64}, x) / a.chol)
+end
 
 ### Algebra
 

--- a/src/scalmat.jl
+++ b/src/scalmat.jl
@@ -14,7 +14,7 @@ Base.convert(::Type{AbstractPDMat{T}}, a::ScalMat) where {T <: Real} = convert(S
 ### Basics
 
 Base.size(a::ScalMat) = (a.dim, a.dim)
-Base.Matrix(a::ScalMat) = Matrix(Diagonal(fill(a.value, a.dim)))
+Base.Matrix{T}(a::ScalMat) where {T} = Matrix{T}(T(a.value) * I, a.dim, a.dim)
 LinearAlgebra.diag(a::ScalMat) = fill(a.value, a.dim)
 LinearAlgebra.cholesky(a::ScalMat) = Cholesky(Diagonal(fill(sqrt(a.value), a.dim)), 'U', 0)
 

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -12,9 +12,12 @@ using PDMats: chol_lower, chol_upper
 
         # allow 5% overhead
         @test chol_lower(C) ≈ chol_upper(C)'
-        broken = v"1.11.5" <= VERSION < v"1.12" && Sys.isapple()
-        @test (@allocated chol_lower(C)) < 1.05 * size_of_one_copy  broken = broken
-        @test (@allocated chol_upper(C)) < 1.05 * size_of_one_copy  broken = broken
+        # The allocation bound is unreliable on Apple (Julia >= 1.11.5): it is met on some
+        # machines but exceeded on others (incl. CI), so skip the check there rather than mark
+        # it `broken` (which errors on the machines where it happens to pass).
+        skip = VERSION >= v"1.11.5" && Sys.isapple()
+        @test (@allocated chol_lower(C)) < 1.05 * size_of_one_copy  skip = skip
+        @test (@allocated chol_upper(C)) < 1.05 * size_of_one_copy  skip = skip
 
         X = randn(d, 10)
         for uplo in (:L, :U)

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -12,7 +12,7 @@ using PDMats: chol_lower, chol_upper
 
         # allow 5% overhead
         @test chol_lower(C) ≈ chol_upper(C)'
-        broken = VERSION >= v"1.11.5" && Sys.isapple()
+        broken = v"1.11.5" <= VERSION < v"1.12" && Sys.isapple()
         @test (@allocated chol_lower(C)) < 1.05 * size_of_one_copy  broken = broken
         @test (@allocated chol_upper(C)) < 1.05 * size_of_one_copy  broken = broken
 

--- a/test/pdmtypes.jl
+++ b/test/pdmtypes.jl
@@ -163,10 +163,8 @@ using Test
         @test size(z) == size(y)
         @test z ≈ y
 
-        # right division not defined for CHOLMOD:
-        # `rdiv!(::Matrix{Float64}, ::SuiteSparse.CHOLMOD.Factor{Float64})` not defined
-        if !HAVE_CHOLMOD
-            z = x / PDSparseMat(sparse(first(A), 1, 1))
+        if HAVE_CHOLMOD
+            z = x / PDSparseMat(sparse(A))
             @test typeof(z) === typeof(y)
             @test size(z) == size(y)
             @test z ≈ y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 include("testutils.jl")
-tests = ["pdmtypes", "abstracttypes", "addition", "congruence", "generics", "kron", "chol", "specialarrays", "sqrt", "ad", "ext/statsbase"]
+tests = ["pdmtypes", "abstracttypes", "addition", "congruence", "generics", "kron", "chol", "specialarrays", "sqrt", "ad", "typeparams", "ext/statsbase"]
 println("Running tests ...")
 
 for t in tests

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -245,25 +245,21 @@ function pdtest_div(C, Imat::Matrix, X::Matrix, verbose::Int)
     @assert d == size(C, 1) == size(C, 2)
     @assert size(Imat) == size(C)
     @test C \ X ≈ Imat * X
-    # CHOLMOD throws error since no method is found for
-    # `rdiv!(::Matrix{Float64}, ::SuiteSparse.CHOLMOD.Factor{Float64})`
-    check_rdiv = !(C isa PDSparseMat && HAVE_CHOLMOD)
-    check_rdiv && @test Matrix(X') / C ≈ (C \ X)'
+    @test Matrix(X') / C ≈ (C \ X)'
 
     for i in 1:n
         xi = vec(copy(X[:, i]))
         @test C \ xi ≈ Imat * xi
-        check_rdiv && @test Matrix(xi') / C ≈ (C \ xi)'
+        @test Matrix(xi') / C ≈ (C \ xi)'
     end
 
 
     # Dimension mismatches
     @test_throws DimensionMismatch C \ rand(d + 1)
     @test_throws DimensionMismatch C \ rand(d + 1, n)
-    return if check_rdiv
-        @test_throws DimensionMismatch rand(1, d + 1) / C
-        @test_throws DimensionMismatch rand(n, d + 1) / C
-    end
+    @test_throws DimensionMismatch rand(1, d + 1) / C
+    @test_throws DimensionMismatch rand(n, d + 1) / C
+    return nothing
 end
 
 

--- a/test/typeparams.jl
+++ b/test/typeparams.jl
@@ -57,10 +57,8 @@ Base.:*(a::MyPD, c::Real) = MyPD(a.value * c)
             M = Matrix(a)
             for x in operands
                 @test a \ x ≈ M \ Array(x)
-                if !(a isa PDSparseMat)  # CHOLMOD has no right division
-                    xt = permutedims(x)
-                    @test xt / a ≈ Array(xt) / M
-                end
+                xt = permutedims(x)
+                @test xt / a ≈ Array(xt) / M
             end
         end
     end

--- a/test/typeparams.jl
+++ b/test/typeparams.jl
@@ -1,0 +1,75 @@
+using PDMats, LinearAlgebra, Test
+
+# Custom subtype for the scalar-multiplication test below; must be top-level since a
+# `struct` cannot be defined inside a `@testset`.
+struct MyPD <: AbstractPDMat{Float64}
+    value::Float64
+end
+Base.size(::MyPD) = (2, 2)
+Base.getindex(a::MyPD, i::Int, j::Int) = i == j ? a.value : 0.0
+Base.:*(a::MyPD, c::Real) = MyPD(a.value * c)
+
+@testset "type parameters" begin
+    @testset "PDMat quad/invquad specialization for Matrix arguments" begin
+        n, k = 200, 500
+        M = randn(n, n)
+        a = PDMat(M * transpose(M) + n * I)
+        x = randn(n, k)
+        xcol = x[:, 1]
+
+        # These also compile the Matrix-argument methods used in the allocation checks below.
+        @test quad(a, x) ≈ diag(transpose(x) * Matrix(a) * x)
+        @test invquad(a, x) ≈ diag(transpose(x) * (a \ x))
+
+        # The specialization reuses one length-n buffer across all columns, so the k-column
+        # call allocates the k-element result plus no more scratch than a single column does.
+        # The generic fallback instead forms the whole n×k product (~140x more here).
+        overhead = 1024
+        quad(a, xcol); invquad(a, xcol)
+        @test (@allocated quad(a, x)) ≤ sizeof(quad(a, x)) + (@allocated quad(a, xcol)) + overhead
+        @test (@allocated invquad(a, x)) ≤ sizeof(invquad(a, x)) + (@allocated invquad(a, xcol)) + overhead
+
+        @test a isa PDMat{<:Real, <:Matrix}
+        @test !(a isa PDMat{<:Real, <:Vector})
+
+        for T in (Float64, Float32)
+            b = PDMat(Matrix{T}(M * transpose(M) + n * I))
+            y = randn(T, n, k)
+            @inferred quad(b, y)
+            @inferred invquad(b, y)
+        end
+    end
+
+    @testset "scalar multiplication via generic fallbacks" begin
+        # `c * a` and `a / c` delegate to a type's own `a * c` without recursing.
+        a = MyPD(3.0)
+        @test (a * 2.0).value == 6.0
+        @test (2.0 * a).value == 6.0
+        @test (a / 2.0).value == 1.5
+    end
+
+    @testset "division accepts mismatched operand element types" begin
+        n = 4
+        mats = Any[_randPDMat(Float64, n), _randPDiagMat(Float64, n), _randScalMat(Float64, n)]
+        HAVE_CHOLMOD && push!(mats, _randPDSparseMat(Float64, n))
+        operands = (rand(1:5, n), rand(1:5, n, 2), randn(Float32, n), randn(Float32, n, 2))
+        for a in mats
+            M = Matrix(a)
+            for x in operands
+                @test a \ x ≈ M \ Array(x)
+                if !(a isa PDSparseMat)  # CHOLMOD has no right division
+                    xt = permutedims(x)
+                    @test xt / a ≈ Array(xt) / M
+                end
+            end
+        end
+    end
+
+    @testset "ScalMat typed conversion" begin
+        a = ScalMat(3, 2.0)
+        @test Matrix(a) isa Matrix{Float64}
+        @test Matrix(a) == [2.0 0 0; 0 2 0; 0 0 2]
+        @test Matrix{Float32}(a) isa Matrix{Float32}
+        @test Matrix{Float32}(a) == Float32[2 0 0; 0 2 0; 0 0 2]
+    end
+end


### PR DESCRIPTION
I noticed these (unrelated) bugs while updating #188:

- The `quad`/`invquad` specializations for `PDMat` were dispatched on `PDMat{<:Real, <:Vector}`. But the second type parameter of `PDMat` is the type of the wrapped matrix (`<:AbstractMatrix`), so this signature can never be satisfied and the specializations were never used — instead the generic fallbacks, which materialize `chol_upper(a) * x`, were called. Changing it to `<:Matrix` restores the intended implementation: for an `n×n` matrix and an `n×k` input the specialization reuses a single length-`n` buffer, so it allocates `O(n + k)` instead of the `O(n*k)` temporary of the fallback.
- `\` and `/` for `PDSparseMat` unnecessarily required the element types of the matrix and the right-hand side to match. Since CHOLMOD only supports `Float64`/`ComplexF64` anyway, this excluded e.g. integer or `Float32` inputs that the other types accept. I relaxed the signatures to `AbstractVecOrMat{<:Real}` and promote the element type of the result.
- The right-division method `/(::AbstractVecOrMat, ::PDSparseMat)` was in fact dead: CHOLMOD provides no right division, so `x / a.chol` always threw a `MethodError`, and every test skipped the sparse right-division path (so it was also uncovered). Since `a` is symmetric, `x / a == (a \ xᵀ)ᵀ`, so I route through the (working, covered) left-division method and enable the previously-skipped right-division tests for `PDSparseMat`.
- I removed the self-recursive definition `*(a::AbstractPDMat, c::Real) = a * c` in `generics.jl`. It is shadowed by the concrete methods of the built-in types but leads to a `StackOverflowError` for other `AbstractPDMat` subtypes.
- For consistency with the other types I defined `Matrix{T}(::ScalMat)` instead of `Matrix(::ScalMat)` (the untyped constructor is provided by `Base`).

Regression tests are added in `test/typeparams.jl`.

The allocation test in `test/chol.jl` was marked broken on Apple since Julia 1.11.5. The bound turns out to be unreliable there in a machine-dependent way: it is met on my Apple silicon machine (Julia 1.12.6) but exceeded on the CI Apple runner for the same version, so neither value of the `broken` marker works for both (it errors as "unexpectedly passing" where it passes, and fails where it doesn't). I therefore `skip` the allocation check on Apple (Julia >= 1.11.5) instead. The marker only ever applied to Apple, so other CI configurations are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
