### PR TITLE
Support adding `AbstractPDMat`s backed by static arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDMats"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.38"
+version = "0.11.39"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -55,18 +55,18 @@ if HAVE_CHOLMOD
     pdadd(a::PDMat, b::PDSparseMat, c::Real) = PDMat(a.mat + b.mat * c)
 end
 
-pdadd(a::PDiagMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.diag, one(c)))
+pdadd(a::PDiagMat, b::PDMat, c::Real) = PDMat(_scaleadddiag(b.mat, c, a.diag))
 pdadd(a::PDiagMat, b::PDiagMat, c::Real) = PDiagMat(a.diag + b.diag * c)
 pdadd(a::PDiagMat, b::ScalMat, c::Real) = PDiagMat(a.diag .+ b.value * c)
 if HAVE_CHOLMOD
-    pdadd(a::PDiagMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.diag, one(c)))
+    pdadd(a::PDiagMat, b::PDSparseMat, c::Real) = PDSparseMat(_scaleadddiag(b.mat, c, a.diag))
 end
 
-pdadd(a::ScalMat, b::PDMat, c::Real) = PDMat(_adddiag!(b.mat * c, a.value))
+pdadd(a::ScalMat, b::PDMat, c::Real) = PDMat(_scaleadddiag(b.mat, c, a.value))
 pdadd(a::ScalMat, b::PDiagMat, c::Real) = PDiagMat(a.value .+ b.diag * c)
 pdadd(a::ScalMat, b::ScalMat, c::Real) = ScalMat(a.dim, a.value + b.value * c)
 if HAVE_CHOLMOD
-    pdadd(a::ScalMat, b::PDSparseMat, c::Real) = PDSparseMat(_adddiag!(b.mat * c, a.value))
+    pdadd(a::ScalMat, b::PDSparseMat, c::Real) = PDSparseMat(_scaleadddiag(b.mat, c, a.value))
 end
 
 if HAVE_CHOLMOD

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,9 +41,32 @@ function _adddiag!(a::Union{Matrix, SparseMatrixCSC}, v::AbstractVector, c::Real
     return a
 end
 
-_adddiag(a::Union{Matrix, SparseMatrixCSC}, v::Real) = _adddiag!(copy(a), v)
-_adddiag(a::Union{Matrix, SparseMatrixCSC}, v::AbstractVector, c::Real) = _adddiag!(copy(a), v, c)
-_adddiag(a::Union{Matrix, SparseMatrixCSC}, v::AbstractVector{T}) where {T <: Real} = _adddiag!(copy(a), v, one(T))
+# Non-mutating diagonal addition: `a + diagonal` (optionally scaled by `c`). These
+# work for dense, sparse, and immutable (e.g. static) matrices, and for dense
+# matrices cost a single allocation just like the in-place path above (which is kept
+# only for the truly in-place `pdadd!`).
+_adddiag(a::AbstractMatrix, v::Real) = a + v * I
+
+function _adddiag(a::AbstractMatrix, v::AbstractVector)
+    @check_argdims eachindex(v) == axes(a, 1) == axes(a, 2)
+    return a + Diagonal(v)
+end
+
+function _adddiag(a::AbstractMatrix, v::AbstractVector, c::Real)
+    @check_argdims eachindex(v) == axes(a, 1) == axes(a, 2)
+    return a .+ c .* Diagonal(v)
+end
+
+# As above, but the coefficient scales the matrix: `c * a + diagonal`. The scalar
+# variant keeps an in-place fast path for mutable storage, since there is no clean
+# single-allocation broadcast for adding a scalar to the diagonal only; other matrix
+# types fall back to `muladd`, allowing fused implementations where available.
+function _scaleadddiag(a::AbstractMatrix, c::Real, v::AbstractVector)
+    @check_argdims eachindex(v) == axes(a, 1) == axes(a, 2)
+    return c .* a .+ Diagonal(v)
+end
+_scaleadddiag(a::AbstractMatrix, c::Real, v::Real) = muladd(c, a, v * I)
+_scaleadddiag(a::Union{Matrix, SparseMatrixCSC}, c::Real, v::Real) = _adddiag!(a * c, v)
 
 
 function wsumsq(w::AbstractVector, a::AbstractVector)

--- a/test/specialarrays.jl
+++ b/test/specialarrays.jl
@@ -108,6 +108,21 @@ using StaticArrays
             @test A - E ≈ Matrix(A) - Matrix(E)
             @test E - A ≈ Matrix(E) - Matrix(A)
         end
+
+        # Addition (issue #167)
+        for A in (PDS, D, E), B in (PDS, D, E)
+            @test A + B ≈ Matrix(A) + Matrix(B)
+            @test pdadd(A, B, 2.0) ≈ Matrix(A) + 2.0 * Matrix(B)
+        end
+        @test (PDS + D) isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
+        @test (D + PDS) isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
+        @test (PDS + E) isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
+        @test (E + PDS) isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
+        @test (D + D) isa PDiagMat{Float64, SVector{4, Float64}}
+        @test (D + E) isa PDiagMat{Float64, SVector{4, Float64}}
+        @test pdadd(PDS, D, 2.0) isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
+        @test pdadd(D, PDS, 2.0) isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
+        @test pdadd(E, PDS, 2.0) isa PDMat{Float64, <:SMatrix{4, 4, Float64}}
     end
 
     @testset "BandedMatrices" begin


### PR DESCRIPTION
Fixes #167.

`+` and `pdadd` of a `PDMat`/`PDiagMat`/`ScalMat` errored when the underlying storage was a static array, e.g.

```julia
PDMat(SMatrix{3,3}(...)) + PDiagMat(SVector{3}(...))
# ERROR: MethodError: no method matching _adddiag(::SMatrix{3,3,Float64,9}, ::SVector{3,Float64})
```

### Root cause
`_adddiag`/`_adddiag!` were only defined for `Union{Matrix, SparseMatrixCSC}` and mutated in place — which is impossible for immutable arrays (and `copy(::SMatrix)` is still immutable). Subtraction already worked because it routes through Base's broadcasting fallback.

### Changes
- Replace the non-mutating `_adddiag` wrappers with generic `AbstractMatrix` methods that build the result by construction (`a + Diagonal(v)`, `a + v*I`, `a .+ c.*Diagonal(v)`). Allocation-measured to match the previous copy-and-mutate path for dense matrices (1 allocation), stay sparse for sparse inputs, and preserve the static container otherwise.
- Add `_scaleadddiag` for the matrix-scaled `pdadd` paths (`c*a + diagonal`), keeping an in-place fast path for mutable storage (avoids a second allocation) and falling back to `muladd` for other matrix types.
- Keep the in-place `_adddiag!` — it is still used by the zero-allocation `pdadd!` and the dense `Matrix(b)` fallbacks.
- Vector-taking variants retain `@check_argdims` to guard against silent broadcast singleton-expansion.

### Tests
Added coverage in `test/specialarrays.jl` for every `+`/`pdadd` combination of `PDMat{SMatrix}` / `PDiagMat{SVector}` / `ScalMat`, asserting both numerical correctness and static-type preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)